### PR TITLE
Cluster A — Punnu core (LRU + events + TTL)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "sassi-macros",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -412,12 +413,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,17 @@ authors = ["Tarunvir Bains"]
 rust-version = "1.95"
 
 [workspace.dependencies]
-# Async substrate
-tokio = { version = "1.48", default-features = false, features = ["sync", "rt"] }
+# Async substrate.
+# `sync` powers the broadcast channel that backs Punnu's event stream
+# (no runtime required; works on WASM too). `rt` + `time` are needed by
+# the optional background TTL sweep task. `macros` powers `#[tokio::test]`
+# in integration tests.
+tokio = { version = "1.48", default-features = false, features = ["sync", "rt", "time", "macros"] }
 futures = "0.3"
+
+# Error derive — `thiserror` is the de facto Rust convention for
+# library error types; keeps Display/Debug impls consistent.
+thiserror = "2"
 
 # Serde — opt-in for cross-runtime wire format
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sassi
 
-**Sassi** is a typed in-memory pool with composable predicate algebra and cross-runtime trait queries — usable from any Rust runtime (backend, Dioxus frontend, WASM) without coupling to a particular ORM, web framework, or storage layer.
+**Sassi** is a typed in-memory pool with composable predicate algebra and cross-runtime trait queries — designed for cross-runtime use (backend or Dioxus frontend) without coupling to a particular ORM, web framework, or storage layer. WASM target support tracking in [issue #3](https://github.com/TarunvirBains/sassi/issues/3) (lands via Cluster B Task 10's `PunnuExecutor` abstraction); see Status below.
 
 ## What it gives you
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 **Pre-v0.1.0 alpha.** This repository is currently a skeleton; implementation lands per the design spec under `docs/superpowers/specs/` (local-only). v0.1.0 ships in lockstep with the [djogi](https://github.com/TarunvirBains/djogi) framework's v0.1.0 cut.
 
+- **WASM target** — deferred per [issue #3](https://github.com/TarunvirBains/sassi/issues/3); supported in v0.1.0 via Cluster B Task 10's `PunnuExecutor` abstraction (with Task 18 closing the CI matrix). The `runtime-wasm` feature flag is declared today as a forward-compatibility hook; no code is gated behind it yet.
+
 ## Workspace layout
 
 ```

--- a/sassi/Cargo.toml
+++ b/sassi/Cargo.toml
@@ -13,14 +13,22 @@ authors.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["serde"]
+# `serde` enables the wire-format envelope (lands in a later cluster).
+# `runtime-tokio` enables the optional background TTL sweep task and is
+# the typical setup for native consumers; tests rely on it via
+# `#[tokio::test]`. `runtime-wasm` is the WASM-target counterpart and
+# selects the gloo-timers-based executor (lands in Task 10).
+default = ["serde", "runtime-tokio"]
 serde = ["dep:serde", "dep:serde_json"]
-# wasm consumers enable runtime-wasm; native consumers enable runtime-tokio
-runtime-tokio = ["tokio"]
+runtime-tokio = []
 runtime-wasm = []
 
 [dependencies]
-tokio = { workspace = true, optional = true }
+# `tokio` is unconditional — the broadcast channel that backs Punnu's
+# event stream lives behind `tokio::sync` and works on every supported
+# target, including WASM. The `runtime-tokio` feature only governs
+# whether the spawn-driven background sweep task is compiled in.
+tokio = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -28,4 +36,5 @@ lru = { workspace = true }
 dashmap = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
+thiserror = { workspace = true }
 sassi-macros = { path = "../sassi-macros", version = "0.1.0-alpha.0" }

--- a/sassi/Cargo.toml
+++ b/sassi/Cargo.toml
@@ -17,7 +17,14 @@ rust-version.workspace = true
 # `runtime-tokio` enables the optional background TTL sweep task and is
 # the typical setup for native consumers; tests rely on it via
 # `#[tokio::test]`. `runtime-wasm` is the WASM-target counterpart and
-# selects the gloo-timers-based executor (lands in Task 10).
+# selects the gloo-timers-based executor.
+#
+# `runtime-wasm` is reserved for Cluster B, Task 10 (`PunnuExecutor`
+# abstraction) — the flag is declared today so consumers see the full
+# feature shape, but no code is gated behind it yet. WASM target
+# verification is tracked at
+# https://github.com/TarunvirBains/sassi/issues/3 (also covers Task 18
+# CI matrix work).
 default = ["serde", "runtime-tokio"]
 serde = ["dep:serde", "dep:serde_json"]
 runtime-tokio = []
@@ -38,3 +45,11 @@ tracing = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 sassi-macros = { path = "../sassi-macros", version = "0.1.0-alpha.0" }
+
+[dev-dependencies]
+# `test-util` enables `tokio::time::pause` / `advance` and the
+# `#[tokio::test(start_paused = true)]` attribute. Required by the
+# TTL test files (`punnu_ttl_lazy.rs`, `punnu_ttl_sweep.rs`) so they
+# can drive virtual time deterministically instead of relying on
+# real `sleep` calls. Dev-only; never linked into a production build.
+tokio = { version = "1.48", default-features = false, features = ["sync", "rt", "time", "macros", "test-util"] }

--- a/sassi/src/error.rs
+++ b/sassi/src/error.rs
@@ -1,0 +1,88 @@
+//! Library-wide error types.
+//!
+//! Sassi's public errors live here so they can compose freely across
+//! modules without cyclic-module headaches. The full set lands across
+//! several tasks (Punnu, single-flight, backend, wire format); this
+//! module grows as those tasks ship.
+//!
+//! Variants present today:
+//! - [`InsertError`] — surfaced from [`crate::punnu::Punnu::insert`] and friends.
+//! - [`BackendError`] — surfaced from the [`CacheBackend`](crate) trait
+//!   (full trait lands in a later task; the variants are pinned now so
+//!   error types that compose with it are stable from v0.1.0-alpha.0
+//!   onward).
+//!
+//! Sassi's error doctrine matches the Rust ecosystem standard:
+//! `thiserror`-derived enums for library types, with `#[error("…")]`
+//! messages that tell the caller what they need to know without
+//! leaking implementation detail.
+
+use thiserror::Error;
+
+/// Reasons a [`crate::punnu::Punnu::insert`] (or the L2 write-through
+/// behind it) can fail.
+///
+/// The default L1-only configuration only ever produces
+/// [`InsertError::Conflict`] (when the pool is configured with
+/// [`crate::punnu::OnConflict::Reject`] and an entry with the same id is
+/// already present). [`InsertError::Serialization`] and
+/// [`InsertError::BackendFailed`] become reachable when an L2 backend
+/// is wired up — the variants live here from day one so the error type
+/// is stable before backends land.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum InsertError {
+    /// Conflict — the pool was configured with
+    /// [`crate::punnu::OnConflict::Reject`] and an entry with the same
+    /// id is already cached. Default conflict policy is
+    /// `LastWriteWins`; this variant is unreachable unless the consumer
+    /// opts in to `Reject`.
+    #[error("entry conflict — OnConflict::Reject configured and id is already cached")]
+    Conflict,
+
+    /// Serialization failed when writing through to the L2 backend.
+    /// Carries a human-readable reason; the backend chooses the wording.
+    #[error("serialization failed during insert: {0}")]
+    Serialization(String),
+
+    /// L2 backend write-through failed and
+    /// [`crate::punnu::BackendFailureMode::Error`] is configured. With
+    /// the default [`crate::punnu::BackendFailureMode::L1Only`], backend
+    /// errors are logged and swallowed — `insert` succeeds against L1
+    /// alone.
+    #[error("backend write-through failed: {0}")]
+    BackendFailed(#[from] BackendError),
+}
+
+/// Errors from the [`CacheBackend`](crate) trait surface.
+///
+/// The full backend trait lands in a later task; the variants are
+/// pinned here so types that compose with it (notably
+/// [`InsertError::BackendFailed`]) have a stable shape from
+/// v0.1.0-alpha.0 onward. Backends choose the variant that best matches
+/// the underlying failure; consumers pattern-match on the variant
+/// rather than parsing the message.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BackendError {
+    /// The backend reports the entry is absent — distinct from a
+    /// transport failure. Surfaces as a `None` to the caller in most
+    /// flows; the dedicated variant exists so backends with strict
+    /// existence semantics can be unambiguous.
+    #[error("backend reports entry not found")]
+    NotFound,
+
+    /// The backend could not serialize or deserialize a payload. The
+    /// inner string is backend-supplied (e.g., serde error rendering).
+    #[error("backend serialization error: {0}")]
+    Serialization(String),
+
+    /// Network / IO transport error. Inner string is backend-supplied.
+    #[error("backend network error: {0}")]
+    Network(String),
+
+    /// Anything that doesn't fit the variants above. Boxed so the
+    /// variant size stays small.
+    #[error("backend error: {0}")]
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -48,8 +48,8 @@ pub use cacheable::{Cacheable, Field};
 pub use error::{BackendError, InsertError};
 pub use predicate::{BasicPredicate, FieldPredicate, LookupOp};
 pub use punnu::{
-    BackendFailureMode, CacheTier, InvalidationReason, OnConflict, Punnu, PunnuBuilder,
-    PunnuConfig, PunnuEvent, PunnuMetrics, TenantKey,
+    BackendFailureMode, CacheTier, EventReason, InvalidationReason, OnConflict, Punnu,
+    PunnuBuilder, PunnuConfig, PunnuEvent, PunnuMetrics, TenantKey,
 };
 
 // Derive macro re-export. The trait and the derive share the name

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -40,10 +40,17 @@
 #![warn(missing_docs)]
 
 pub mod cacheable;
+pub mod error;
 pub mod predicate;
+pub mod punnu;
 
 pub use cacheable::{Cacheable, Field};
+pub use error::{BackendError, InsertError};
 pub use predicate::{BasicPredicate, FieldPredicate, LookupOp};
+pub use punnu::{
+    BackendFailureMode, CacheTier, InvalidationReason, OnConflict, Punnu, PunnuBuilder,
+    PunnuConfig, PunnuEvent, PunnuMetrics, TenantKey,
+};
 
 // Derive macro re-export. The trait and the derive share the name
 // `Cacheable` (different namespaces — type namespace for the trait,

--- a/sassi/src/punnu/config.rs
+++ b/sassi/src/punnu/config.rs
@@ -17,15 +17,23 @@
 //! native consumer" — 10k-entry LRU, 256-event channel, L1-only on
 //! backend failure, last-write-wins on conflict, no TTL, no metrics.
 //!
-//! Several fields ([`PunnuConfig::default_ttl`],
-//! [`PunnuConfig::ttl_sweep_interval`], [`PunnuConfig::namespace`],
-//! [`PunnuConfig::metrics`]) wire up across multiple tasks; their
-//! variants are pinned here so the config shape is stable from
-//! v0.1.0-alpha.0 onward — adopters see the full surface, even though
-//! some hooks are not yet load-bearing.
+//! Several fields wire up across multiple tasks; their variants are
+//! pinned here so the config shape is stable from v0.1.0-alpha.0
+//! onward — adopters see the full surface, even though some hooks are
+//! not yet load-bearing. Each field's doc comment names the specific
+//! cluster/task that loads it:
+//!
+//! - [`PunnuConfig::default_ttl`] / [`PunnuConfig::ttl_sweep_interval`]
+//!   — already load-bearing in Cluster A, Task 6.
+//! - [`PunnuConfig::namespace`] — wired into `CacheBackend` keys in
+//!   Cluster D, Task 13.
+//! - [`PunnuConfig::metrics`] — hook called from `Punnu::insert` /
+//!   `get` / `invalidate` in Cluster B, Task 8.
+//! - [`PunnuConfig::backend_failure_mode`] — routing logic lives in
+//!   Cluster D, Task 13 (`CacheBackend` integration).
 
 use crate::error::BackendError;
-use crate::punnu::events::InvalidationReason;
+use crate::punnu::events::EventReason;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -59,7 +67,8 @@ pub struct PunnuConfig {
     /// What to do when an L2 backend write-through fails during
     /// [`crate::punnu::Punnu::insert`]. Default
     /// [`BackendFailureMode::L1Only`] — log the error, succeed against
-    /// L1 alone. Loaded by the L2 wiring landing in a later task.
+    /// L1 alone. Routing logic lives in Cluster D, Task 13
+    /// (`CacheBackend` integration).
     pub backend_failure_mode: BackendFailureMode,
 
     /// What to do when [`crate::punnu::Punnu::insert`] is called for an
@@ -88,7 +97,7 @@ pub struct PunnuConfig {
     /// production setups typically use `"prod_v1"` / `"staging_v1"`,
     /// and tests use a per-run UUID for parallel isolation. L1
     /// storage is unaffected — namespacing governs only L2 keys.
-    /// Wires up when L2 backends land in a later task.
+    /// Wired into `CacheBackend` keys in Cluster D, Task 13.
     pub namespace: Option<String>,
 
     /// Optional observability hook. When `Some`, every event of
@@ -98,6 +107,8 @@ pub struct PunnuConfig {
     /// metrics layer they already use (Prometheus, OpenTelemetry,
     /// statsd, …) without sassi pulling in a metrics framework.
     /// Default `None` is a no-op that costs nothing at runtime.
+    /// Hook called from `Punnu::insert` / `get` / `invalidate` in
+    /// Cluster B, Task 8.
     pub metrics: Option<Arc<dyn PunnuMetrics>>,
 }
 
@@ -178,7 +189,7 @@ pub enum OnConflict {
     LastWriteWins,
 
     /// New insert returns
-    /// [`crate::punnu::InsertError::Conflict`]; the existing entry is
+    /// [`crate::error::InsertError::Conflict`]; the existing entry is
     /// left in place.
     Reject,
 
@@ -220,8 +231,11 @@ pub trait PunnuMetrics: Send + Sync {
     /// An entry left the cache. The reason discriminator lets metrics
     /// distinguish LRU pressure (undersized capacity) from TTL expiry
     /// (configured freshness window) from manual / save / delete
-    /// invalidation.
-    fn record_eviction(&self, type_name: &'static str, reason: InvalidationReason);
+    /// invalidation. Takes the full [`EventReason`] taxonomy — metrics
+    /// dashboards typically split by every reason, including the
+    /// system-internal `LruEvict` / `TtlExpired` / `BackendInvalidation`
+    /// reasons that callers cannot directly trigger.
+    fn record_eviction(&self, type_name: &'static str, reason: EventReason);
 
     /// An L2 backend operation failed. Surfaces the underlying
     /// [`BackendError`] so dashboards can split by failure mode

--- a/sassi/src/punnu/config.rs
+++ b/sassi/src/punnu/config.rs
@@ -1,0 +1,241 @@
+//! [`PunnuConfig`] — runtime configuration for a [`crate::punnu::Punnu`]
+//! instance.
+//!
+//! Construction is via `PunnuConfig::default()` followed by struct-update
+//! syntax, e.g.:
+//!
+//! ```
+//! use sassi::PunnuConfig;
+//! let cfg = PunnuConfig {
+//!     lru_size: 64,
+//!     ..Default::default()
+//! };
+//! ```
+//!
+//! All fields are public so consumers can read them back via
+//! [`crate::punnu::Punnu::config`]. Defaults are tuned for "typical
+//! native consumer" — 10k-entry LRU, 256-event channel, L1-only on
+//! backend failure, last-write-wins on conflict, no TTL, no metrics.
+//!
+//! Several fields ([`PunnuConfig::default_ttl`],
+//! [`PunnuConfig::ttl_sweep_interval`], [`PunnuConfig::namespace`],
+//! [`PunnuConfig::metrics`]) wire up across multiple tasks; their
+//! variants are pinned here so the config shape is stable from
+//! v0.1.0-alpha.0 onward — adopters see the full surface, even though
+//! some hooks are not yet load-bearing.
+
+use crate::error::BackendError;
+use crate::punnu::events::InvalidationReason;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Tuning knobs for a [`crate::punnu::Punnu`] instance.
+///
+/// Constructed via the builder ([`crate::punnu::Punnu::builder`]) or
+/// passed directly to [`crate::punnu::PunnuBuilder::config`]. Fields
+/// are public so consumers can read them back via
+/// [`crate::punnu::Punnu::config`] — useful for diagnostics and tests.
+///
+/// **Forward compatibility:** the canonical construction pattern is
+/// `PunnuConfig { lru_size: …, ..Default::default() }`. Future
+/// minor releases add fields with sensible defaults; consumers using
+/// the `..Default::default()` form upgrade without source changes.
+/// Construct *exhaustively* and you'll need to revisit on each minor
+/// upgrade.
+pub struct PunnuConfig {
+    /// LRU capacity in entries. Default `10_000`. Must be non-zero —
+    /// the builder enforces this at construction time and panics with a
+    /// descriptive message if zero is passed (caller bug, not a runtime
+    /// failure mode).
+    pub lru_size: usize,
+
+    /// Backing capacity of the broadcast channel that powers the event
+    /// stream. Default `256`. Lossy by design: when a subscriber lags
+    /// past this many events, the channel drops the oldest events for
+    /// that subscriber and surfaces `RecvError::Lagged` on the next
+    /// receive. Producer-side `send` calls never block.
+    pub event_channel_capacity: usize,
+
+    /// What to do when an L2 backend write-through fails during
+    /// [`crate::punnu::Punnu::insert`]. Default
+    /// [`BackendFailureMode::L1Only`] — log the error, succeed against
+    /// L1 alone. Loaded by the L2 wiring landing in a later task.
+    pub backend_failure_mode: BackendFailureMode,
+
+    /// What to do when [`crate::punnu::Punnu::insert`] is called for an
+    /// id that's already cached. Default
+    /// [`OnConflict::LastWriteWins`].
+    pub on_conflict: OnConflict,
+
+    /// Default TTL applied to entries inserted via
+    /// [`crate::punnu::Punnu::insert`]. `None` (default) means entries
+    /// never expire on time. Per-entry overrides via
+    /// [`crate::punnu::Punnu::insert_with_ttl`].
+    pub default_ttl: Option<Duration>,
+
+    /// Optional background-sweep interval. `None` (default) leaves
+    /// expired entries in storage until the next `get` triggers the
+    /// lazy expiry path; `Some(d)` spawns a task that scans the L1
+    /// every `d` and removes anything that's already expired.
+    /// Spawning requires the `runtime-tokio` feature; on WASM (with
+    /// the `runtime-wasm` executor landing in a later task) this
+    /// becomes the executor's responsibility. See spec §6.2.5 for the
+    /// contract.
+    pub ttl_sweep_interval: Option<Duration>,
+
+    /// Backend cache-key namespace prepended to all L2 backend keys.
+    /// `None` (default) is fine for single-environment deployments;
+    /// production setups typically use `"prod_v1"` / `"staging_v1"`,
+    /// and tests use a per-run UUID for parallel isolation. L1
+    /// storage is unaffected — namespacing governs only L2 keys.
+    /// Wires up when L2 backends land in a later task.
+    pub namespace: Option<String>,
+
+    /// Optional observability hook. When `Some`, every event of
+    /// interest fires a method on the consumer-supplied
+    /// implementation. The trait is intentionally narrow — sassi
+    /// commits to surfacing these counters; consumers wire to whatever
+    /// metrics layer they already use (Prometheus, OpenTelemetry,
+    /// statsd, …) without sassi pulling in a metrics framework.
+    /// Default `None` is a no-op that costs nothing at runtime.
+    pub metrics: Option<Arc<dyn PunnuMetrics>>,
+}
+
+impl Default for PunnuConfig {
+    fn default() -> Self {
+        Self {
+            lru_size: 10_000,
+            event_channel_capacity: 256,
+            backend_failure_mode: BackendFailureMode::L1Only,
+            on_conflict: OnConflict::LastWriteWins,
+            default_ttl: None,
+            ttl_sweep_interval: None,
+            namespace: None,
+            metrics: None,
+        }
+    }
+}
+
+// `PunnuConfig` does not derive `Debug` because the `metrics` field
+// (an `Arc<dyn PunnuMetrics>`) is not `Debug`. Manual impl elides the
+// metrics handle while keeping the rest debuggable.
+impl std::fmt::Debug for PunnuConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PunnuConfig")
+            .field("lru_size", &self.lru_size)
+            .field("event_channel_capacity", &self.event_channel_capacity)
+            .field("backend_failure_mode", &self.backend_failure_mode)
+            .field("on_conflict", &self.on_conflict)
+            .field("default_ttl", &self.default_ttl)
+            .field("ttl_sweep_interval", &self.ttl_sweep_interval)
+            .field("namespace", &self.namespace)
+            .field("metrics", &self.metrics.as_ref().map(|_| "<configured>"))
+            .finish()
+    }
+}
+
+/// Behaviour when an L2 backend write-through fails.
+///
+/// Defaults to [`BackendFailureMode::L1Only`] — the most permissive
+/// mode, suitable for caches that are an optimisation rather than a
+/// correctness boundary. Consumers with stricter consistency
+/// requirements should pick [`BackendFailureMode::Error`] (propagate)
+/// or [`BackendFailureMode::Retry`] (retry-with-backoff before falling
+/// through). Loaded by the L2 wiring landing in a later task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendFailureMode {
+    /// Log the backend error, fall back to L1-only. Insert / get /
+    /// invalidate succeed against L1 even if the backend is
+    /// unreachable. The recommended default.
+    L1Only,
+
+    /// Propagate the backend error to the caller.
+    /// `insert` returns `Err(InsertError::BackendFailed(...))`,
+    /// `get_async` returns `Err(BackendError)`. Use when the L2 tier
+    /// is a correctness requirement, not an optimisation.
+    Error,
+
+    /// Retry the backend operation up to `attempts` times before
+    /// falling through to L1Only behaviour. Backoff strategy is left
+    /// to the backend implementation (no global retry policy).
+    Retry {
+        /// Number of attempts before giving up.
+        attempts: u8,
+    },
+}
+
+/// Behaviour when [`crate::punnu::Punnu::insert`] is called for an id
+/// that's already cached.
+///
+/// Defaults to [`OnConflict::LastWriteWins`] — straightforward identity-map
+/// semantics, suitable for "the most recent value the consumer
+/// produced is canonical". `Reject` and `Update` give consumers the
+/// other two reasonable shapes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnConflict {
+    /// New insert overwrites the existing entry; emits
+    /// [`crate::punnu::PunnuEvent::Insert`].
+    LastWriteWins,
+
+    /// New insert returns
+    /// [`crate::punnu::InsertError::Conflict`]; the existing entry is
+    /// left in place.
+    Reject,
+
+    /// New insert overwrites the existing entry, but emits
+    /// [`crate::punnu::PunnuEvent::Update`] (carrying both the old and
+    /// the new value) instead of `Insert`.
+    Update,
+}
+
+/// Cache tier — used by [`PunnuMetrics::record_hit`] to disambiguate
+/// L1 (in-memory) hits from L2 (backend) hits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheTier {
+    /// L1 — in-process LRU.
+    L1,
+    /// L2 — pluggable backend (Redis, Postgres, file, memory).
+    L2,
+}
+
+/// Observability hook. Sassi commits to firing these counters on every
+/// event of interest; consumers wire to whatever metrics layer they
+/// already use (Prometheus, OpenTelemetry, statsd, …) without sassi
+/// pulling in a metrics framework.
+///
+/// Implementations must be `Send + Sync` because the trait object is
+/// shared across the broadcast subscriber side and the operation
+/// callsites. All methods take `&self` — implementations typically
+/// forward to atomic counters or a metrics-library handle.
+///
+/// `type_name` is `std::any::type_name::<T>()` — pre-baked at compile
+/// time, zero-runtime-cost, suitable for a Prometheus label.
+pub trait PunnuMetrics: Send + Sync {
+    /// A `get` (or `get_or_fetch`) hit served from the named tier.
+    fn record_hit(&self, type_name: &'static str, tier: CacheTier);
+
+    /// A `get` miss — neither L1 nor L2 had the entry.
+    fn record_miss(&self, type_name: &'static str);
+
+    /// An entry left the cache. The reason discriminator lets metrics
+    /// distinguish LRU pressure (undersized capacity) from TTL expiry
+    /// (configured freshness window) from manual / save / delete
+    /// invalidation.
+    fn record_eviction(&self, type_name: &'static str, reason: InvalidationReason);
+
+    /// An L2 backend operation failed. Surfaces the underlying
+    /// [`BackendError`] so dashboards can split by failure mode
+    /// (network vs. serialization vs. not-found).
+    fn record_backend_error(&self, type_name: &'static str, err: &BackendError);
+
+    /// End-to-end fetch latency for `get_or_fetch`-style flows. Wires
+    /// up when single-flight lands in a later task; included now so
+    /// the trait shape is stable.
+    fn record_fetch_latency(&self, type_name: &'static str, duration: Duration);
+
+    /// L1 entry count, sampled — useful for "is the LRU near its
+    /// capacity?" alerts. Sassi calls this opportunistically (after
+    /// inserts and invalidations); consumers should treat it as a
+    /// gauge sample, not a stream of every change.
+    fn record_lru_size(&self, type_name: &'static str, size: usize);
+}

--- a/sassi/src/punnu/events.rs
+++ b/sassi/src/punnu/events.rs
@@ -162,6 +162,26 @@ pub enum InvalidationReason {
     OnDelete,
 }
 
+/// Sealed marker for [`EventReason`]'s system-internal variants.
+///
+/// Held as the payload of [`EventReason::LruEvict`] /
+/// [`EventReason::TtlExpired`] / [`EventReason::BackendInvalidation`].
+/// The struct itself is `pub` so external code can pattern-match on the
+/// containing variants (`EventReason::LruEvict(_)` requires the field
+/// type to be visible). Construction is sealed because the inner `()`
+/// is a private positional field — `Internal(())` requires a private
+/// field, which external code can't write. Use [`Internal::new`]
+/// (`pub(crate)`) inside sassi.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Internal(());
+
+impl Internal {
+    /// Internal constructor — sassi-only.
+    pub(crate) const fn new() -> Self {
+        Self(())
+    }
+}
+
 /// Full invalidation taxonomy emitted on [`PunnuEvent::Invalidate`].
 ///
 /// Includes both the public reasons callers can pass to
@@ -172,6 +192,13 @@ pub enum InvalidationReason {
 /// Subscribers see this enum on the event stream; only the
 /// [`InvalidationReason`] subset is reachable through the public
 /// `invalidate` call path.
+///
+/// The internal variants carry a `pub(crate) Internal` marker as their
+/// payload: external code can pattern-match (`EventReason::LruEvict(_)`)
+/// but cannot construct (`EventReason::LruEvict(...)` requires a value
+/// of an unnameable type). Combined with the `#[non_exhaustive]` enum
+/// marker, this means subscribers see internal reasons but never
+/// synthesise them.
 ///
 /// The variants are stable wire-level identifiers — distributed
 /// backends fan invalidations across processes by reason, so adding a
@@ -201,14 +228,16 @@ pub enum EventReason {
     /// from [`EventReason::TtlExpired`] for metrics: an LRU-driven
     /// eviction often indicates an undersized `lru_size`, while a
     /// TTL-driven eviction indicates the configured freshness window.
-    /// Not reachable via [`crate::punnu::Punnu::invalidate`].
-    LruEvict,
+    /// Not reachable via [`crate::punnu::Punnu::invalidate`]; cannot
+    /// be constructed externally (the `Internal` marker is `pub(crate)`).
+    LruEvict(Internal),
 
     /// System-internal: the entry's TTL elapsed. Either a lazy check
     /// on `get` observed expiry, or the optional background sweep
     /// task removed the entry mid-tick. See spec §6.2.5 for the TTL
-    /// contract. Not reachable via [`crate::punnu::Punnu::invalidate`].
-    TtlExpired,
+    /// contract. Not reachable via [`crate::punnu::Punnu::invalidate`];
+    /// cannot be constructed externally.
+    TtlExpired(Internal),
 
     /// System-internal: a distributed cache backend (Redis pub/sub,
     /// Postgres LISTEN/NOTIFY, …) pushed an invalidation that the
@@ -216,8 +245,9 @@ pub enum EventReason {
     /// `CacheBackend::invalidation_stream` consumer in Cluster D,
     /// Task 13; pinned now so subscribers can pattern-match against
     /// it from v0.1.0-alpha.0 onward. Not reachable via
-    /// [`crate::punnu::Punnu::invalidate`].
-    BackendInvalidation,
+    /// [`crate::punnu::Punnu::invalidate`]; cannot be constructed
+    /// externally.
+    BackendInvalidation(Internal),
 }
 
 impl From<InvalidationReason> for EventReason {

--- a/sassi/src/punnu/events.rs
+++ b/sassi/src/punnu/events.rs
@@ -1,0 +1,159 @@
+//! [`PunnuEvent`] — the event type broadcast over the
+//! [`crate::punnu::Punnu`] event stream.
+//!
+//! Events are **lossy by design**: when a subscriber falls behind the
+//! configured channel capacity ([`crate::punnu::PunnuConfig::event_channel_capacity`],
+//! default 256), the backing
+//! [`tokio::sync::broadcast`] channel drops the oldest events for that
+//! subscriber and surfaces a `RecvError::Lagged` on the next receive.
+//! The producer (the `Punnu` itself) never blocks and never errors
+//! when receivers lag — slow subscribers degrade to skipped events,
+//! the cache itself stays healthy.
+//!
+//! The same lossy contract holds when there are zero subscribers: a
+//! `send` with no receivers returns `Err(SendError)` which the Punnu
+//! ignores. Events are best-effort observability, not a durable log.
+
+use crate::cacheable::Cacheable;
+use std::sync::Arc;
+
+/// A single observable event from a [`crate::punnu::Punnu`].
+///
+/// Generic over the cached type `T` so subscribers can match on the
+/// payload without boxing. Carries `Arc<T>` for `Insert` / `Update` so
+/// consumers can hold a reference to the entry without copying it.
+///
+/// `PunnuEvent<T>` does **not** require `T: Debug` — `T` is often a
+/// payload type that doesn't derive `Debug`. Subscribers that want
+/// debug output should match on the variant and format their own
+/// fields.
+pub enum PunnuEvent<T: Cacheable> {
+    /// A new entry landed in the cache. With
+    /// [`crate::punnu::OnConflict::LastWriteWins`] (default) this fires
+    /// for both first-insert and replace; with
+    /// [`crate::punnu::OnConflict::Update`], replaces produce
+    /// [`PunnuEvent::Update`] instead and `Insert` fires only on
+    /// first-insert.
+    Insert {
+        /// Newly-cached value.
+        value: Arc<T>,
+    },
+
+    /// An existing entry was replaced under
+    /// [`crate::punnu::OnConflict::Update`].
+    /// Carries both the previous and the new value so subscribers can
+    /// diff them; the new value is also reachable via
+    /// `punnu.get(&id)` after the event fires.
+    Update {
+        /// Previous cached value, just unseated.
+        old: Arc<T>,
+        /// Replacement value, now live in the cache.
+        new: Arc<T>,
+    },
+
+    /// An entry left the cache. Carries the id and the reason so
+    /// subscribers can distinguish manual invalidation, LRU eviction,
+    /// and TTL expiry — common patterns (e.g., metrics, distributed
+    /// invalidation fan-out) want to react differently per reason.
+    Invalidate {
+        /// Id of the entry that left.
+        id: T::Id,
+        /// Why the entry left.
+        reason: InvalidationReason,
+    },
+}
+
+// `Clone` is required by `tokio::sync::broadcast` for the message
+// type. We implement it manually rather than deriving so the bound
+// remains `T: Cacheable` (without forcing `T: Clone` — `Arc<T>` is
+// already `Clone` regardless of `T`).
+impl<T: Cacheable> Clone for PunnuEvent<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Insert { value } => Self::Insert {
+                value: value.clone(),
+            },
+            Self::Update { old, new } => Self::Update {
+                old: old.clone(),
+                new: new.clone(),
+            },
+            Self::Invalidate { id, reason } => Self::Invalidate {
+                id: id.clone(),
+                reason: *reason,
+            },
+        }
+    }
+}
+
+// Manual `Debug` so the event type is debuggable without requiring
+// `T: Debug` (id is always Debug-renderable via the trait bound below;
+// we use the type name for the value placeholder rather than the
+// payload itself, which matches the spec's "type_name as a metrics
+// label" pattern).
+impl<T: Cacheable> std::fmt::Debug for PunnuEvent<T>
+where
+    T::Id: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Insert { .. } => f
+                .debug_struct("PunnuEvent::Insert")
+                .field("value_ty", &std::any::type_name::<T>())
+                .finish(),
+            Self::Update { .. } => f
+                .debug_struct("PunnuEvent::Update")
+                .field("value_ty", &std::any::type_name::<T>())
+                .finish(),
+            Self::Invalidate { id, reason } => f
+                .debug_struct("PunnuEvent::Invalidate")
+                .field("id", id)
+                .field("reason", reason)
+                .finish(),
+        }
+    }
+}
+
+/// Why an entry left the cache. Surfaced inside
+/// [`PunnuEvent::Invalidate`].
+///
+/// The variants are stable wire-level identifiers — distributed
+/// backends fan invalidations across processes by reason, so adding a
+/// new variant is a minor-version event and removing one is a
+/// breaking change. Sassi reserves the right to add new variants in
+/// future minor releases (the type is `#[non_exhaustive]`).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidationReason {
+    /// Caller explicitly invalidated the entry — e.g.,
+    /// `punnu.invalidate(&id, InvalidationReason::Manual).await`.
+    Manual,
+
+    /// LRU eviction — the cache was at capacity and pushed this entry
+    /// to make room for a newer one. Distinguishable from
+    /// [`InvalidationReason::TtlExpired`] for metrics: an LRU-driven
+    /// eviction often indicates an undersized `lru_size`, while a
+    /// TTL-driven eviction indicates the configured freshness window.
+    LruEvict,
+
+    /// Driven by a successful `Model::save` on the bound
+    /// `DjogiContext` (the same-process invalidation path described
+    /// in spec §6.1). Sassi-side semantics: the consumer surfaces this
+    /// reason; sassi records it.
+    OnSave,
+
+    /// Driven by a successful `Model::delete` on the bound
+    /// `DjogiContext` (spec §6.1).
+    OnDelete,
+
+    /// A distributed cache backend (Redis pub/sub, Postgres
+    /// LISTEN/NOTIFY, …) pushed an invalidation that the
+    /// [`crate::punnu::Punnu`] applied locally. Wires up in a later
+    /// task (full backend trait); pinned now so subscribers can
+    /// pattern-match against it from v0.1.0-alpha.0 onward.
+    BackendInvalidation,
+
+    /// The entry's TTL elapsed. Either a lazy check on `get`
+    /// observed expiry, or the optional background sweep task removed
+    /// the entry mid-tick. See spec §6.2.5 for the TTL contract.
+    TtlExpired,
+}

--- a/sassi/src/punnu/events.rs
+++ b/sassi/src/punnu/events.rs
@@ -162,26 +162,6 @@ pub enum InvalidationReason {
     OnDelete,
 }
 
-/// Sealed marker for [`EventReason`]'s system-internal variants.
-///
-/// Held as the payload of [`EventReason::LruEvict`] /
-/// [`EventReason::TtlExpired`] / [`EventReason::BackendInvalidation`].
-/// The struct itself is `pub` so external code can pattern-match on the
-/// containing variants (`EventReason::LruEvict(_)` requires the field
-/// type to be visible). Construction is sealed because the inner `()`
-/// is a private positional field — `Internal(())` requires a private
-/// field, which external code can't write. Use [`Internal::new`]
-/// (`pub(crate)`) inside sassi.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Internal(());
-
-impl Internal {
-    /// Internal constructor — sassi-only.
-    pub(crate) const fn new() -> Self {
-        Self(())
-    }
-}
-
 /// Full invalidation taxonomy emitted on [`PunnuEvent::Invalidate`].
 ///
 /// Includes both the public reasons callers can pass to
@@ -193,12 +173,15 @@ impl Internal {
 /// [`InvalidationReason`] subset is reachable through the public
 /// `invalidate` call path.
 ///
-/// The internal variants carry a `pub(crate) Internal` marker as their
-/// payload: external code can pattern-match (`EventReason::LruEvict(_)`)
-/// but cannot construct (`EventReason::LruEvict(...)` requires a value
-/// of an unnameable type). Combined with the `#[non_exhaustive]` enum
-/// marker, this means subscribers see internal reasons but never
-/// synthesise them.
+/// The system-internal variants are individually marked
+/// `#[non_exhaustive]`. Per the Rust reference, this prevents external
+/// crates from constructing them via the unit syntax — sassi can
+/// still write `EventReason::LruEvict` internally, but external code
+/// cannot. Pattern-matching from outside requires the `{ .. }` rest
+/// pattern (e.g. `EventReason::LruEvict { .. }`), which keeps the
+/// invariant enforceable: external code can observe internal reasons
+/// but never synthesise them, even by token reuse or bit-pattern
+/// transmutation (no payload exists to forge).
 ///
 /// The variants are stable wire-level identifiers — distributed
 /// backends fan invalidations across processes by reason, so adding a
@@ -228,16 +211,19 @@ pub enum EventReason {
     /// from [`EventReason::TtlExpired`] for metrics: an LRU-driven
     /// eviction often indicates an undersized `lru_size`, while a
     /// TTL-driven eviction indicates the configured freshness window.
-    /// Not reachable via [`crate::punnu::Punnu::invalidate`]; cannot
-    /// be constructed externally (the `Internal` marker is `pub(crate)`).
-    LruEvict(Internal),
+    /// Not reachable via [`crate::punnu::Punnu::invalidate`]; sealed
+    /// against external construction by the per-variant
+    /// `#[non_exhaustive]` marker.
+    #[non_exhaustive]
+    LruEvict,
 
     /// System-internal: the entry's TTL elapsed. Either a lazy check
     /// on `get` observed expiry, or the optional background sweep
     /// task removed the entry mid-tick. See spec §6.2.5 for the TTL
     /// contract. Not reachable via [`crate::punnu::Punnu::invalidate`];
-    /// cannot be constructed externally.
-    TtlExpired(Internal),
+    /// sealed against external construction.
+    #[non_exhaustive]
+    TtlExpired,
 
     /// System-internal: a distributed cache backend (Redis pub/sub,
     /// Postgres LISTEN/NOTIFY, …) pushed an invalidation that the
@@ -245,9 +231,10 @@ pub enum EventReason {
     /// `CacheBackend::invalidation_stream` consumer in Cluster D,
     /// Task 13; pinned now so subscribers can pattern-match against
     /// it from v0.1.0-alpha.0 onward. Not reachable via
-    /// [`crate::punnu::Punnu::invalidate`]; cannot be constructed
-    /// externally.
-    BackendInvalidation(Internal),
+    /// [`crate::punnu::Punnu::invalidate`]; sealed against external
+    /// construction.
+    #[non_exhaustive]
+    BackendInvalidation,
 }
 
 impl From<InvalidationReason> for EventReason {

--- a/sassi/src/punnu/events.rs
+++ b/sassi/src/punnu/events.rs
@@ -179,9 +179,11 @@ pub enum InvalidationReason {
 /// still write `EventReason::LruEvict` internally, but external code
 /// cannot. Pattern-matching from outside requires the `{ .. }` rest
 /// pattern (e.g. `EventReason::LruEvict { .. }`), which keeps the
-/// invariant enforceable: external code can observe internal reasons
-/// but never synthesise them, even by token reuse or bit-pattern
-/// transmutation (no payload exists to forge).
+/// invariant enforceable through Rust's safe surface: external code
+/// can observe internal reasons but has no safe construction path to
+/// synthesise them. (Arbitrary downstream `unsafe` can transmute its
+/// way around any privacy boundary in Rust; this seal is a safe-code
+/// guarantee, not a hard impossibility.)
 ///
 /// The variants are stable wire-level identifiers — distributed
 /// backends fan invalidations across processes by reason, so adding a

--- a/sassi/src/punnu/events.rs
+++ b/sassi/src/punnu/events.rs
@@ -27,6 +27,19 @@ use std::sync::Arc;
 /// payload type that doesn't derive `Debug`. Subscribers that want
 /// debug output should match on the variant and format their own
 /// fields.
+///
+/// # Reason taxonomy: [`EventReason`] vs. [`InvalidationReason`]
+///
+/// [`PunnuEvent::Invalidate`] carries an [`EventReason`] — the full
+/// taxonomy including system-internal reasons ([`EventReason::LruEvict`],
+/// [`EventReason::TtlExpired`], [`EventReason::BackendInvalidation`])
+/// that the runtime constructs but callers cannot synthesise.
+/// [`crate::punnu::Punnu::invalidate`] takes the narrower
+/// [`InvalidationReason`] enum, which is the public subset
+/// (`Manual` / `OnSave` / `OnDelete`). The split keeps the call-side
+/// API honest — callers can't pass `LruEvict` to `invalidate` — while
+/// subscribers continue to see one unified reason discriminator on the
+/// event stream.
 pub enum PunnuEvent<T: Cacheable> {
     /// A new entry landed in the cache. With
     /// [`crate::punnu::OnConflict::LastWriteWins`] (default) this fires
@@ -55,11 +68,17 @@ pub enum PunnuEvent<T: Cacheable> {
     /// subscribers can distinguish manual invalidation, LRU eviction,
     /// and TTL expiry — common patterns (e.g., metrics, distributed
     /// invalidation fan-out) want to react differently per reason.
+    ///
+    /// `reason` is an [`EventReason`] (the full taxonomy) rather than
+    /// an [`InvalidationReason`] (the public subset accepted by
+    /// [`crate::punnu::Punnu::invalidate`]). System-internal reasons
+    /// like [`EventReason::LruEvict`] and [`EventReason::TtlExpired`]
+    /// are reachable here even though no caller can construct them.
     Invalidate {
         /// Id of the entry that left.
         id: T::Id,
-        /// Why the entry left.
-        reason: InvalidationReason,
+        /// Why the entry left — full taxonomy.
+        reason: EventReason,
     },
 }
 
@@ -113,8 +132,12 @@ where
     }
 }
 
-/// Why an entry left the cache. Surfaced inside
-/// [`PunnuEvent::Invalidate`].
+/// Caller-supplied invalidation reason — the public subset accepted by
+/// [`crate::punnu::Punnu::invalidate`].
+///
+/// Externally-initiated invalidation only. System-internal reasons
+/// (LRU eviction, TTL expiry, backend-driven invalidation) live in the
+/// sibling [`EventReason`] enum; callers cannot synthesise those.
 ///
 /// The variants are stable wire-level identifiers — distributed
 /// backends fan invalidations across processes by reason, so adding a
@@ -128,13 +151,6 @@ pub enum InvalidationReason {
     /// `punnu.invalidate(&id, InvalidationReason::Manual).await`.
     Manual,
 
-    /// LRU eviction — the cache was at capacity and pushed this entry
-    /// to make room for a newer one. Distinguishable from
-    /// [`InvalidationReason::TtlExpired`] for metrics: an LRU-driven
-    /// eviction often indicates an undersized `lru_size`, while a
-    /// TTL-driven eviction indicates the configured freshness window.
-    LruEvict,
-
     /// Driven by a successful `Model::save` on the bound
     /// `DjogiContext` (the same-process invalidation path described
     /// in spec §6.1). Sassi-side semantics: the consumer surfaces this
@@ -144,16 +160,72 @@ pub enum InvalidationReason {
     /// Driven by a successful `Model::delete` on the bound
     /// `DjogiContext` (spec §6.1).
     OnDelete,
+}
 
-    /// A distributed cache backend (Redis pub/sub, Postgres
-    /// LISTEN/NOTIFY, …) pushed an invalidation that the
-    /// [`crate::punnu::Punnu`] applied locally. Wires up in a later
-    /// task (full backend trait); pinned now so subscribers can
-    /// pattern-match against it from v0.1.0-alpha.0 onward.
-    BackendInvalidation,
+/// Full invalidation taxonomy emitted on [`PunnuEvent::Invalidate`].
+///
+/// Includes both the public reasons callers can pass to
+/// [`crate::punnu::Punnu::invalidate`] (lifted in via the
+/// [`From<InvalidationReason>`] conversion) and the system-internal
+/// reasons sassi constructs itself ([`EventReason::LruEvict`],
+/// [`EventReason::TtlExpired`], [`EventReason::BackendInvalidation`]).
+/// Subscribers see this enum on the event stream; only the
+/// [`InvalidationReason`] subset is reachable through the public
+/// `invalidate` call path.
+///
+/// The variants are stable wire-level identifiers — distributed
+/// backends fan invalidations across processes by reason, so adding a
+/// new variant is a minor-version event and removing one is a
+/// breaking change. Sassi reserves the right to add new variants in
+/// future minor releases (the type is `#[non_exhaustive]`).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventReason {
+    /// Caller-driven invalidation — public path
+    /// [`crate::punnu::Punnu::invalidate`] with
+    /// [`InvalidationReason::Manual`].
+    Manual,
 
-    /// The entry's TTL elapsed. Either a lazy check on `get`
-    /// observed expiry, or the optional background sweep task removed
-    /// the entry mid-tick. See spec §6.2.5 for the TTL contract.
+    /// Caller-driven invalidation — public path
+    /// [`crate::punnu::Punnu::invalidate`] with
+    /// [`InvalidationReason::OnSave`].
+    OnSave,
+
+    /// Caller-driven invalidation — public path
+    /// [`crate::punnu::Punnu::invalidate`] with
+    /// [`InvalidationReason::OnDelete`].
+    OnDelete,
+
+    /// System-internal: LRU eviction. The cache was at capacity and
+    /// pushed this entry to make room for a newer one. Distinguishable
+    /// from [`EventReason::TtlExpired`] for metrics: an LRU-driven
+    /// eviction often indicates an undersized `lru_size`, while a
+    /// TTL-driven eviction indicates the configured freshness window.
+    /// Not reachable via [`crate::punnu::Punnu::invalidate`].
+    LruEvict,
+
+    /// System-internal: the entry's TTL elapsed. Either a lazy check
+    /// on `get` observed expiry, or the optional background sweep
+    /// task removed the entry mid-tick. See spec §6.2.5 for the TTL
+    /// contract. Not reachable via [`crate::punnu::Punnu::invalidate`].
     TtlExpired,
+
+    /// System-internal: a distributed cache backend (Redis pub/sub,
+    /// Postgres LISTEN/NOTIFY, …) pushed an invalidation that the
+    /// [`crate::punnu::Punnu`] applied locally. Pushed by the
+    /// `CacheBackend::invalidation_stream` consumer in Cluster D,
+    /// Task 13; pinned now so subscribers can pattern-match against
+    /// it from v0.1.0-alpha.0 onward. Not reachable via
+    /// [`crate::punnu::Punnu::invalidate`].
+    BackendInvalidation,
+}
+
+impl From<InvalidationReason> for EventReason {
+    fn from(r: InvalidationReason) -> Self {
+        match r {
+            InvalidationReason::Manual => Self::Manual,
+            InvalidationReason::OnSave => Self::OnSave,
+            InvalidationReason::OnDelete => Self::OnDelete,
+        }
+    }
 }

--- a/sassi/src/punnu/mod.rs
+++ b/sassi/src/punnu/mod.rs
@@ -1,0 +1,26 @@
+//! [`Punnu<T>`] — typed in-memory pool with composable predicate
+//! filtering, an event stream, and (later tasks) single-flight fetch
+//! coalescing, opt-in TTL, and pluggable L2 backends.
+//!
+//! See the spec at `docs/superpowers/specs/2026-04-30-sassi-design.md`
+//! §3.5 for the public-API surface, §3.5.1 for the single-flight +
+//! per-process invariants, and §6 for the invalidation contract.
+//!
+//! # Cluster A scope
+//!
+//! This cluster (Tasks 4-6 of the v0.1.0 plan) lands the core pool
+//! shape: identity-map storage with LRU eviction, the broadcast event
+//! stream, and TTL-driven expiry (lazy + opt-in background sweep).
+//! Single-flight, scopes, backends, executors, refresh, and the
+//! orchestrator surface ship in subsequent clusters.
+
+pub mod config;
+pub mod events;
+pub mod pool;
+pub mod tenant;
+pub(crate) mod ttl;
+
+pub use config::{BackendFailureMode, CacheTier, OnConflict, PunnuConfig, PunnuMetrics};
+pub use events::{InvalidationReason, PunnuEvent};
+pub use pool::{Punnu, PunnuBuilder};
+pub use tenant::TenantKey;

--- a/sassi/src/punnu/mod.rs
+++ b/sassi/src/punnu/mod.rs
@@ -21,6 +21,6 @@ pub mod tenant;
 pub(crate) mod ttl;
 
 pub use config::{BackendFailureMode, CacheTier, OnConflict, PunnuConfig, PunnuMetrics};
-pub use events::{InvalidationReason, PunnuEvent};
+pub use events::{EventReason, InvalidationReason, PunnuEvent};
 pub use pool::{Punnu, PunnuBuilder};
 pub use tenant::TenantKey;

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -225,7 +225,7 @@ impl<T: Cacheable> Punnu<T> {
         {
             let _ = self.inner.events.send(PunnuEvent::Invalidate {
                 id: evicted_id,
-                reason: EventReason::LruEvict(crate::punnu::events::Internal::new()),
+                reason: EventReason::LruEvict,
             });
         }
 
@@ -302,7 +302,7 @@ impl<T: Cacheable> Punnu<T> {
         if expired {
             let _ = self.inner.events.send(PunnuEvent::Invalidate {
                 id: id.clone(),
-                reason: EventReason::TtlExpired(crate::punnu::events::Internal::new()),
+                reason: EventReason::TtlExpired,
             });
         }
         None

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -26,15 +26,19 @@
 use crate::cacheable::Cacheable;
 use crate::error::InsertError;
 use crate::punnu::config::{OnConflict, PunnuConfig};
-use crate::punnu::events::{InvalidationReason, PunnuEvent};
+use crate::punnu::events::{EventReason, InvalidationReason, PunnuEvent};
 use crate::punnu::ttl::Entry;
 #[cfg(feature = "runtime-tokio")]
 use crate::punnu::ttl::spawn_sweep;
 use lru::LruCache;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::sync::broadcast;
+// `tokio::time::Instant` is a drop-in for `std::time::Instant` that
+// honours `tokio::time::pause()` / `advance()` in tests. See the same
+// rationale in `crate::punnu::ttl`. Production behaviour is unchanged.
+use tokio::time::Instant;
 
 /// Typed in-memory pool — the cache primitive. See module-level docs
 /// for concurrency and identity-map contract.
@@ -103,6 +107,7 @@ impl<T: Cacheable> Punnu<T> {
     /// #     type Id = i64;
     /// #     type Fields = UserFields;
     /// #     fn id(&self) -> i64 { self.id }
+    /// #     fn fields() -> UserFields { UserFields }
     /// # }
     /// # #[derive(Default)] struct UserFields;
     /// let pool: Punnu<User> = Punnu::builder().build();
@@ -129,7 +134,7 @@ impl<T: Cacheable> Punnu<T> {
     ///
     /// If the insert pushes the LRU past `lru_size`, the
     /// least-recently-used entry is evicted and an
-    /// [`InvalidationReason::LruEvict`] event fires before the
+    /// [`EventReason::LruEvict`] event fires before the
     /// `Insert` / `Update` event.
     ///
     /// `async` because L2 backend write-through (a later task) is
@@ -219,7 +224,7 @@ impl<T: Cacheable> Punnu<T> {
         {
             let _ = self.inner.events.send(PunnuEvent::Invalidate {
                 id: evicted_id,
-                reason: InvalidationReason::LruEvict,
+                reason: EventReason::LruEvict,
             });
         }
 
@@ -256,7 +261,7 @@ impl<T: Cacheable> Punnu<T> {
     ///
     /// 1. The entry is removed from L1.
     /// 2. A [`PunnuEvent::Invalidate`] with reason
-    ///    [`InvalidationReason::TtlExpired`] is emitted.
+    ///    [`EventReason::TtlExpired`] is emitted.
     /// 3. `None` is returned.
     ///
     /// The expiry check + removal happen under the same write lock
@@ -296,7 +301,7 @@ impl<T: Cacheable> Punnu<T> {
         if expired {
             let _ = self.inner.events.send(PunnuEvent::Invalidate {
                 id: id.clone(),
-                reason: InvalidationReason::TtlExpired,
+                reason: EventReason::TtlExpired,
             });
         }
         None
@@ -304,11 +309,33 @@ impl<T: Cacheable> Punnu<T> {
 
     /// Drop a single entry by id. No-op if the id is not cached.
     /// Emits [`PunnuEvent::Invalidate`] with the supplied reason
-    /// when an entry was actually removed.
+    /// (lifted into the wider [`EventReason`] taxonomy) when an entry
+    /// was actually removed.
+    ///
+    /// Accepts only the [`InvalidationReason`] subset
+    /// (`Manual` / `OnSave` / `OnDelete`) — system-internal reasons
+    /// like LRU eviction or TTL expiry are constructed by sassi itself
+    /// and surface on the event stream as [`EventReason::LruEvict`] /
+    /// [`EventReason::TtlExpired`], not via this entry point.
     ///
     /// `async` because L2 backend invalidation (a later task) is
     /// async; the L1-only path resolves immediately.
     pub async fn invalidate(&self, id: &T::Id, reason: InvalidationReason) {
+        self.invalidate_internal(id, EventReason::from(reason))
+            .await
+    }
+
+    /// Internal invalidation entry point — accepts the full
+    /// [`EventReason`] taxonomy so sassi-internal call sites (LRU
+    /// pressure that bypasses `LruCache::push`, TTL sweep, future
+    /// backend-driven invalidation) can emit system-internal reasons
+    /// without going through [`InvalidationReason`].
+    ///
+    /// Identical L1 semantics to [`Punnu::invalidate`] otherwise.
+    /// `pub(crate)` so it cannot be used by external callers — that
+    /// would defeat the public-vs-internal split that motivates the
+    /// two enums.
+    pub(crate) async fn invalidate_internal(&self, id: &T::Id, reason: EventReason) {
         let removed = {
             let mut map = self.inner.map.write().expect(
                 "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
@@ -411,6 +438,7 @@ impl<T: Cacheable> PunnuBuilder<T> {
     /// #     type Id = i64;
     /// #     type Fields = UserFields;
     /// #     fn id(&self) -> i64 { self.id }
+    /// #     fn fields() -> UserFields { UserFields }
     /// # }
     /// # #[derive(Default)] struct UserFields;
     /// let pool: Punnu<User> = Punnu::builder()
@@ -436,9 +464,20 @@ impl<T: Cacheable> PunnuBuilder<T> {
     ///
     /// # Panics
     ///
-    /// Panics if `config.lru_size == 0` — a zero-capacity LRU is a
-    /// programmer error, not a runtime failure mode (every insert
-    /// would immediately evict itself).
+    /// Panics if any of the following config invariants is violated;
+    /// the builder catches the bad shape at construction time so the
+    /// failure surfaces with a clear message instead of a cryptic panic
+    /// from a downstream primitive (`tokio::time::interval(0)` or
+    /// `broadcast::channel(0)`):
+    ///
+    /// - `config.lru_size == 0` — a zero-capacity LRU evicts every
+    ///   insert immediately, which is a programmer error.
+    /// - `config.ttl_sweep_interval == Some(Duration::ZERO)` — would
+    ///   reach `tokio::time::interval(0)` and panic at runtime. Use
+    ///   `None` to disable the sweep.
+    /// - `config.event_channel_capacity == 0` — would reach
+    ///   `broadcast::channel(0)` and panic at runtime. The minimum
+    ///   sensible value is `1`.
     pub fn build(self) -> Punnu<T> {
         let cap = NonZeroUsize::new(self.config.lru_size).unwrap_or_else(|| {
             panic!(
@@ -446,6 +485,18 @@ impl<T: Cacheable> PunnuBuilder<T> {
                  a zero-capacity LRU evicts every insert immediately"
             )
         });
+        if let Some(d) = self.config.ttl_sweep_interval {
+            assert!(
+                !d.is_zero(),
+                "PunnuConfig::ttl_sweep_interval must be greater than Duration::ZERO; \
+                 use None to disable the background sweep"
+            );
+        }
+        assert!(
+            self.config.event_channel_capacity > 0,
+            "PunnuConfig::event_channel_capacity must be greater than 0; \
+             the broadcast channel rejects a zero capacity"
+        );
         let sweep_interval = self.config.ttl_sweep_interval;
         let (events, _) = broadcast::channel(self.config.event_channel_capacity);
         let inner = Arc::new(PunnuInner {

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -1,0 +1,384 @@
+//! [`Punnu<T>`] — the typed in-memory pool.
+//!
+//! Holds `Arc<PunnuInner<T>>` so the public `Punnu<T>` is cheap to
+//! clone and shareable across tasks; every clone observes the same
+//! identity map, the same event stream, and the same configuration.
+//!
+//! # Concurrency
+//!
+//! The L1 storage is a [`std::sync::RwLock`] around an `LruCache`
+//! rather than an async lock. Two reasons:
+//!
+//! 1. The spec calls `get` synchronous (§3.5) — `tokio::sync::RwLock`
+//!    has no sync `read()`, so picking a sync lock is the only way to
+//!    keep the public surface as designed.
+//! 2. The `lru` crate's `get` method takes `&mut self` (it touches the
+//!    LRU recency order on access), so even read-shaped operations
+//!    need exclusive access to the map. A sync `RwLock<LruCache>`
+//!    therefore behaves like a sync `Mutex<LruCache>` in practice;
+//!    the `RwLock` shape leaves headroom for future LRU implementations
+//!    that genuinely support `&self` reads (e.g., a clock-based variant)
+//!    without changing the field type.
+//!
+//! Locks are held only across pure in-memory work (no awaits, no IO),
+//! so a sync lock under an async runtime is safe.
+
+use crate::cacheable::Cacheable;
+use crate::error::InsertError;
+use crate::punnu::config::{OnConflict, PunnuConfig};
+use crate::punnu::events::{InvalidationReason, PunnuEvent};
+use crate::punnu::ttl::Entry;
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, RwLock};
+use tokio::sync::broadcast;
+
+/// Typed in-memory pool — the cache primitive. See module-level docs
+/// for concurrency and identity-map contract.
+///
+/// `Punnu<T>` is a thin handle around an `Arc<PunnuInner<T>>`; cloning
+/// a `Punnu<T>` clones the `Arc`, not the underlying state. Multiple
+/// clones observe the same identity map, the same event stream, and
+/// the same configuration. This is the intended sharing pattern —
+/// hand `Punnu<T>` clones to request handlers, background tasks, and
+/// scopes alike.
+///
+/// # Lifecycle
+///
+/// 1. Construct via [`Punnu::builder`].
+/// 2. [`Punnu::insert`] entries (or via [`Punnu::insert_with_ttl`] in
+///    a later task — pinned in the trait now for forward
+///    compatibility; the method ships in the TTL task).
+/// 3. [`Punnu::get`] entries by id (synchronous).
+/// 4. [`Punnu::invalidate`] entries explicitly, or let LRU / TTL
+///    pressure evict them.
+/// 5. Subscribe to [`Punnu::events`] for an observability stream.
+///
+/// Drop the last `Punnu<T>` clone to release the inner state — any
+/// background sweep task (Task 6) checks the strong count via
+/// `Arc::downgrade` and exits cleanly.
+pub struct Punnu<T: Cacheable> {
+    inner: Arc<PunnuInner<T>>,
+}
+
+impl<T: Cacheable> Clone for Punnu<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// Internal shared state — held behind `Arc` so `Punnu<T>` is cheaply
+/// cloneable.
+///
+/// `pub(crate)` so the sweep task (Task 6) and the scope handle (Task
+/// 11) can observe state directly without going through `Punnu<T>`.
+pub(crate) struct PunnuInner<T: Cacheable> {
+    /// L1 identity map. See module-level docs for the lock choice
+    /// rationale.
+    pub(crate) map: RwLock<LruCache<T::Id, Entry<T>>>,
+
+    /// Lossy-by-design event channel; see
+    /// [`crate::punnu::PunnuEvent`].
+    pub(crate) events: broadcast::Sender<PunnuEvent<T>>,
+
+    /// Configuration captured at build time. Held by reference via
+    /// [`Punnu::config`]; not mutated after construction.
+    pub(crate) config: PunnuConfig,
+}
+
+impl<T: Cacheable> Punnu<T> {
+    /// Begin building a [`Punnu<T>`]. See [`PunnuBuilder`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sassi::Punnu;
+    ///
+    /// # struct User { id: i64 }
+    /// # impl sassi::Cacheable for User {
+    /// #     type Id = i64;
+    /// #     type Fields = UserFields;
+    /// #     fn id(&self) -> i64 { self.id }
+    /// # }
+    /// # #[derive(Default)] struct UserFields;
+    /// let pool: Punnu<User> = Punnu::builder().build();
+    /// ```
+    pub fn builder() -> PunnuBuilder<T> {
+        PunnuBuilder::new()
+    }
+
+    /// Insert a value into the pool.
+    ///
+    /// Identity-map semantics: the entry is keyed by `value.id()`. If
+    /// an entry with the same id is already cached, behaviour follows
+    /// [`PunnuConfig::on_conflict`]:
+    ///
+    /// - [`OnConflict::LastWriteWins`] (default) — the new value
+    ///   replaces the existing one; emits
+    ///   [`PunnuEvent::Insert`].
+    /// - [`OnConflict::Reject`] — returns
+    ///   [`InsertError::Conflict`]; the existing entry is left in
+    ///   place.
+    /// - [`OnConflict::Update`] — the new value replaces the existing
+    ///   one; emits [`PunnuEvent::Update`] carrying both the old and
+    ///   the new value.
+    ///
+    /// If the insert pushes the LRU past `lru_size`, the
+    /// least-recently-used entry is evicted and an
+    /// [`InvalidationReason::LruEvict`] event fires before the
+    /// `Insert` / `Update` event.
+    ///
+    /// `async` because L2 backend write-through (a later task) is
+    /// async; the L1-only path resolves immediately.
+    ///
+    /// # Errors
+    ///
+    /// - [`InsertError::Conflict`] if [`OnConflict::Reject`] is
+    ///   configured and the id already exists.
+    /// - [`InsertError::BackendFailed`] / [`InsertError::Serialization`]
+    ///   become reachable when L2 backends land in a later task.
+    pub async fn insert(&self, value: T) -> Result<Arc<T>, InsertError> {
+        let arc = Arc::new(value);
+        self.insert_arc_internal(arc).await
+    }
+
+    /// Internal insert — shared by `insert` (and, in Task 6,
+    /// `insert_with_ttl`).
+    async fn insert_arc_internal(&self, arc: Arc<T>) -> Result<Arc<T>, InsertError> {
+        let id = arc.id();
+        let entry = Entry::new(arc.clone());
+
+        // Locking + push are pure in-memory work — no awaits while
+        // holding the lock.
+        let outcome = {
+            let mut map = self.inner.map.write().expect(
+                "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
+            );
+
+            // Probe whether the id is already present *before* we
+            // mutate, so we can decide on `Reject` / `Update` without
+            // having to undo a `push`. `LruCache::peek` does not
+            // touch recency order, which is what we want here.
+            let existing = map.peek(&id).cloned();
+
+            if existing.is_some() && matches!(self.inner.config.on_conflict, OnConflict::Reject) {
+                return Err(InsertError::Conflict);
+            }
+
+            // `LruCache::push` returns Some((k, v)) for both
+            // replacement (k == inserted id) and capacity-driven
+            // eviction (k != inserted id). We disambiguate by
+            // comparing keys.
+            let pushed = map.push(id.clone(), entry);
+            InsertOutcome {
+                existing,
+                replaced_or_evicted: pushed,
+            }
+        };
+
+        // Drop the lock before emitting events — broadcast `send`
+        // does no IO but does signal subscribers, and we don't want
+        // any subscriber-side latency to add to lock-hold time.
+
+        // First emit the LRU-eviction event, if any. Replace and
+        // capacity-eviction look identical at the `lru` API level;
+        // disambiguate by key comparison.
+        if let Some((evicted_id, _evicted_entry)) = outcome.replaced_or_evicted
+            && evicted_id != id
+        {
+            let _ = self.inner.events.send(PunnuEvent::Invalidate {
+                id: evicted_id,
+                reason: InvalidationReason::LruEvict,
+            });
+        }
+
+        // Then emit the insert / update event, choosing the variant
+        // by `OnConflict` policy.
+        let event = match (outcome.existing, self.inner.config.on_conflict) {
+            (Some(old), OnConflict::Update) => PunnuEvent::Update {
+                old: old.value,
+                new: arc.clone(),
+            },
+            // LastWriteWins (or any other path that didn't bail out
+            // earlier) emits `Insert`. The "Reject" path returned
+            // before reaching this point.
+            _ => PunnuEvent::Insert { value: arc.clone() },
+        };
+        let _ = self.inner.events.send(event);
+
+        Ok(arc)
+    }
+
+    /// Synchronous L1 lookup. Returns `Some(Arc<T>)` if the id is
+    /// cached, `None` if it isn't.
+    ///
+    /// On hit, refreshes the entry's LRU recency. (`LruCache::get`
+    /// takes `&mut self` precisely because it updates the recency
+    /// list — that's why this method takes the write lock even
+    /// though it's read-shaped at the API level. See module-level
+    /// docs.)
+    ///
+    /// TTL-aware lazy expiry wires up in a later task; for now an
+    /// expired entry is still served (the storage layer carries
+    /// `expires_at` from day one, but the check itself lands with
+    /// the TTL behaviour).
+    pub fn get(&self, id: &T::Id) -> Option<Arc<T>> {
+        let mut map =
+            self.inner.map.write().expect(
+                "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
+            );
+        map.get(id).map(|entry| entry.value.clone())
+    }
+
+    /// Drop a single entry by id. No-op if the id is not cached.
+    /// Emits [`PunnuEvent::Invalidate`] with the supplied reason
+    /// when an entry was actually removed.
+    ///
+    /// `async` because L2 backend invalidation (a later task) is
+    /// async; the L1-only path resolves immediately.
+    pub async fn invalidate(&self, id: &T::Id, reason: InvalidationReason) {
+        let removed = {
+            let mut map = self.inner.map.write().expect(
+                "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
+            );
+            map.pop(id).is_some()
+        };
+        if removed {
+            let _ = self.inner.events.send(PunnuEvent::Invalidate {
+                id: id.clone(),
+                reason,
+            });
+        }
+    }
+
+    /// Number of entries currently in the L1.
+    ///
+    /// Snapshots the current size; concurrent inserts / invalidates
+    /// against another `Punnu<T>` clone may change the value before
+    /// the caller reads it. Suitable for diagnostics and tests, not
+    /// for "is the entry I just inserted definitely visible?" checks
+    /// — use `get` for that.
+    pub fn len(&self) -> usize {
+        self.inner
+            .map
+            .read()
+            .expect("Punnu L1 lock poisoned — a previous panic left it in an inconsistent state")
+            .len()
+    }
+
+    /// `true` iff [`Punnu::len`] is zero. Convenience predicate; same
+    /// snapshot semantics as `len`.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Subscribe to the broadcast event stream.
+    ///
+    /// Each subscriber gets a fresh `Receiver` that observes events
+    /// from this point forward — backfill of past events is not
+    /// supported. Lossy under load: if the subscriber lags past
+    /// [`PunnuConfig::event_channel_capacity`], the channel drops the
+    /// oldest events and the next `recv` returns
+    /// `RecvError::Lagged(skipped)`. The producer never blocks.
+    pub fn events(&self) -> broadcast::Receiver<PunnuEvent<T>> {
+        self.inner.events.subscribe()
+    }
+
+    /// Borrow the captured configuration.
+    pub fn config(&self) -> &PunnuConfig {
+        &self.inner.config
+    }
+
+    // `scope()` (the predicate-driven query handle) lands in Task 11
+    // alongside the `MemQ<T>` extension algebra. Until then, callers
+    // compose with `Punnu::get` / iteration over `events()`. See
+    // `docs/superpowers/plans/2026-05-01-sassi-v0.1.0.md` Task 11.
+}
+
+/// Outcome of an `LruCache::push` pass — captured under the lock and
+/// returned for event emission once the lock is released.
+struct InsertOutcome<T: Cacheable> {
+    /// Snapshot of the prior entry, if any. Held so the `Update`
+    /// event can carry `old`.
+    existing: Option<Entry<T>>,
+    /// Whatever `LruCache::push` returned — `Some` for both replace
+    /// and capacity-driven eviction; disambiguate by key comparison
+    /// against the inserted id.
+    replaced_or_evicted: Option<(T::Id, Entry<T>)>,
+}
+
+/// Builder for [`Punnu<T>`]. Construct via [`Punnu::builder`].
+///
+/// The builder pattern lets the v0.1 surface stay narrow while
+/// reserving room for `.with_backend(...)`, `.with_executor(...)`,
+/// `.with_tenant(...)` setters that land in later tasks. Today the
+/// only active configuration path is `.config(c)`, which captures a
+/// fully-formed [`PunnuConfig`].
+pub struct PunnuBuilder<T: Cacheable> {
+    config: PunnuConfig,
+    _marker: std::marker::PhantomData<fn() -> T>,
+}
+
+impl<T: Cacheable> PunnuBuilder<T> {
+    /// Fresh builder with default configuration. Most consumers
+    /// reach this via [`Punnu::builder`].
+    pub fn new() -> Self {
+        Self {
+            config: PunnuConfig::default(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Replace the captured configuration wholesale. Use struct-update
+    /// syntax to override individual fields:
+    ///
+    /// ```
+    /// # use sassi::{Punnu, PunnuConfig};
+    /// # struct User { id: i64 }
+    /// # impl sassi::Cacheable for User {
+    /// #     type Id = i64;
+    /// #     type Fields = UserFields;
+    /// #     fn id(&self) -> i64 { self.id }
+    /// # }
+    /// # #[derive(Default)] struct UserFields;
+    /// let pool: Punnu<User> = Punnu::builder()
+    ///     .config(PunnuConfig { lru_size: 128, ..Default::default() })
+    ///     .build();
+    /// ```
+    pub fn config(mut self, config: PunnuConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Finalize the builder.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `config.lru_size == 0` — a zero-capacity LRU is a
+    /// programmer error, not a runtime failure mode (every insert
+    /// would immediately evict itself).
+    pub fn build(self) -> Punnu<T> {
+        let cap = NonZeroUsize::new(self.config.lru_size).unwrap_or_else(|| {
+            panic!(
+                "PunnuConfig::lru_size must be non-zero (got 0); \
+                 a zero-capacity LRU evicts every insert immediately"
+            )
+        });
+        let (events, _) = broadcast::channel(self.config.event_channel_capacity);
+        Punnu {
+            inner: Arc::new(PunnuInner {
+                map: RwLock::new(LruCache::new(cap)),
+                events,
+                config: self.config,
+            }),
+        }
+    }
+}
+
+impl<T: Cacheable> Default for PunnuBuilder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -37,7 +37,8 @@ use std::time::Duration;
 use tokio::sync::broadcast;
 // `tokio::time::Instant` is a drop-in for `std::time::Instant` that
 // honours `tokio::time::pause()` / `advance()` in tests. See the same
-// rationale in `crate::punnu::ttl`. Production behaviour is unchanged.
+// rationale in `crate::punnu::ttl`. Production behaviour is unchanged
+// — both types read the system monotonic clock outside of `pause()`.
 use tokio::time::Instant;
 
 /// Typed in-memory pool — the cache primitive. See module-level docs
@@ -224,7 +225,7 @@ impl<T: Cacheable> Punnu<T> {
         {
             let _ = self.inner.events.send(PunnuEvent::Invalidate {
                 id: evicted_id,
-                reason: EventReason::LruEvict,
+                reason: EventReason::LruEvict(crate::punnu::events::Internal::new()),
             });
         }
 
@@ -301,7 +302,7 @@ impl<T: Cacheable> Punnu<T> {
         if expired {
             let _ = self.inner.events.send(PunnuEvent::Invalidate {
                 id: id.clone(),
-                reason: EventReason::TtlExpired,
+                reason: EventReason::TtlExpired(crate::punnu::events::Internal::new()),
             });
         }
         None

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -28,9 +28,12 @@ use crate::error::InsertError;
 use crate::punnu::config::{OnConflict, PunnuConfig};
 use crate::punnu::events::{InvalidationReason, PunnuEvent};
 use crate::punnu::ttl::Entry;
+#[cfg(feature = "runtime-tokio")]
+use crate::punnu::ttl::spawn_sweep;
 use lru::LruCache;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 
 /// Typed in-memory pool — the cache primitive. See module-level docs
@@ -46,17 +49,16 @@ use tokio::sync::broadcast;
 /// # Lifecycle
 ///
 /// 1. Construct via [`Punnu::builder`].
-/// 2. [`Punnu::insert`] entries (or via [`Punnu::insert_with_ttl`] in
-///    a later task — pinned in the trait now for forward
-///    compatibility; the method ships in the TTL task).
-/// 3. [`Punnu::get`] entries by id (synchronous).
+/// 2. [`Punnu::insert`] (uses [`PunnuConfig::default_ttl`]) or
+///    [`Punnu::insert_with_ttl`] (per-entry TTL override) entries.
+/// 3. [`Punnu::get`] entries by id (synchronous; lazy TTL check).
 /// 4. [`Punnu::invalidate`] entries explicitly, or let LRU / TTL
 ///    pressure evict them.
 /// 5. Subscribe to [`Punnu::events`] for an observability stream.
 ///
-/// Drop the last `Punnu<T>` clone to release the inner state — any
-/// background sweep task (Task 6) checks the strong count via
-/// `Arc::downgrade` and exits cleanly.
+/// Drop the last `Punnu<T>` clone to release the inner state — the
+/// optional background TTL sweep task uses `Arc::downgrade` and
+/// exits cleanly when the strong count reaches zero.
 pub struct Punnu<T: Cacheable> {
     inner: Arc<PunnuInner<T>>,
 }
@@ -139,16 +141,43 @@ impl<T: Cacheable> Punnu<T> {
     ///   configured and the id already exists.
     /// - [`InsertError::BackendFailed`] / [`InsertError::Serialization`]
     ///   become reachable when L2 backends land in a later task.
+    ///
+    /// # TTL
+    ///
+    /// Uses [`PunnuConfig::default_ttl`] when set, otherwise the entry
+    /// has no expiry deadline. Per-entry overrides go through
+    /// [`Punnu::insert_with_ttl`].
     pub async fn insert(&self, value: T) -> Result<Arc<T>, InsertError> {
+        let ttl = self.inner.config.default_ttl;
         let arc = Arc::new(value);
-        self.insert_arc_internal(arc).await
+        self.insert_arc_internal(arc, ttl).await
     }
 
-    /// Internal insert — shared by `insert` (and, in Task 6,
-    /// `insert_with_ttl`).
-    async fn insert_arc_internal(&self, arc: Arc<T>) -> Result<Arc<T>, InsertError> {
+    /// Insert with an explicit TTL — overrides
+    /// [`PunnuConfig::default_ttl`] for this entry. Pass any large
+    /// duration (e.g., `Duration::MAX`) to effectively disable TTL
+    /// for this entry without touching the pool's default.
+    ///
+    /// All other semantics match [`Punnu::insert`] — identity-map,
+    /// `OnConflict` policy, LRU pressure, event emission. The `ttl`
+    /// is added to `Instant::now()` at the moment of insert; clock
+    /// adjustments after insert do not change the deadline.
+    pub async fn insert_with_ttl(&self, value: T, ttl: Duration) -> Result<Arc<T>, InsertError> {
+        let arc = Arc::new(value);
+        self.insert_arc_internal(arc, Some(ttl)).await
+    }
+
+    /// Internal insert — shared by `insert` and `insert_with_ttl`.
+    /// `ttl` is the absolute TTL applied to this entry (`None` means
+    /// no expiry).
+    async fn insert_arc_internal(
+        &self,
+        arc: Arc<T>,
+        ttl: Option<Duration>,
+    ) -> Result<Arc<T>, InsertError> {
         let id = arc.id();
-        let entry = Entry::new(arc.clone());
+        let expires_at = ttl.map(|d| Instant::now() + d);
+        let entry = Entry::with_expiry(arc.clone(), expires_at);
 
         // Locking + push are pure in-memory work — no awaits while
         // holding the lock.
@@ -212,7 +241,8 @@ impl<T: Cacheable> Punnu<T> {
     }
 
     /// Synchronous L1 lookup. Returns `Some(Arc<T>)` if the id is
-    /// cached, `None` if it isn't.
+    /// cached and unexpired; `None` if it isn't cached **or** the
+    /// entry's TTL has elapsed.
     ///
     /// On hit, refreshes the entry's LRU recency. (`LruCache::get`
     /// takes `&mut self` precisely because it updates the recency
@@ -220,16 +250,56 @@ impl<T: Cacheable> Punnu<T> {
     /// though it's read-shaped at the API level. See module-level
     /// docs.)
     ///
-    /// TTL-aware lazy expiry wires up in a later task; for now an
-    /// expired entry is still served (the storage layer carries
-    /// `expires_at` from day one, but the check itself lands with
-    /// the TTL behaviour).
+    /// # TTL semantics (lazy expiry path)
+    ///
+    /// If the entry exists but `expires_at <= Instant::now()`:
+    ///
+    /// 1. The entry is removed from L1.
+    /// 2. A [`PunnuEvent::Invalidate`] with reason
+    ///    [`InvalidationReason::TtlExpired`] is emitted.
+    /// 3. `None` is returned.
+    ///
+    /// The expiry check + removal happen under the same write lock
+    /// so concurrent `get`s observe a consistent state — at most one
+    /// `TtlExpired` event fires for a given expired entry, even
+    /// under contention.
     pub fn get(&self, id: &T::Id) -> Option<Arc<T>> {
-        let mut map =
-            self.inner.map.write().expect(
+        // Fast path: peek first to avoid the write lock when the id
+        // is missing entirely. `peek` does not touch recency, so the
+        // lookup-on-hit path still needs the write lock — but a miss
+        // is the common cold-cache case, so the read-only peek is
+        // worth the branch.
+        let expired = {
+            let mut map = self.inner.map.write().expect(
                 "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
             );
-        map.get(id).map(|entry| entry.value.clone())
+            // Peek first to make the expiry decision *without*
+            // touching recency. If the peeked entry is fresh, fall
+            // through to `get` (which touches recency) and return
+            // the value. If it's expired, pop it under the same
+            // lock — that's the race-safe spot to decide who fires
+            // `TtlExpired`.
+            let peeked = map.peek(id)?;
+            if peeked.is_expired() {
+                map.pop(id);
+                true
+            } else {
+                // `get` is guaranteed to find the entry — we just
+                // peeked it under the same write lock.
+                let entry = map
+                    .get(id)
+                    .expect("entry present (just peeked under same lock)");
+                return Some(entry.value.clone());
+            }
+        };
+
+        if expired {
+            let _ = self.inner.events.send(PunnuEvent::Invalidate {
+                id: id.clone(),
+                reason: InvalidationReason::TtlExpired,
+            });
+        }
+        None
     }
 
     /// Drop a single entry by id. No-op if the id is not cached.
@@ -354,6 +424,16 @@ impl<T: Cacheable> PunnuBuilder<T> {
 
     /// Finalize the builder.
     ///
+    /// If [`PunnuConfig::ttl_sweep_interval`] is `Some`, spawns a
+    /// background tokio task that scans the L1 every interval tick
+    /// for TTL-expired entries (gated behind the `runtime-tokio`
+    /// feature; WASM consumers wait on the executor abstraction
+    /// landing in a later task). The sweep task uses
+    /// [`std::sync::Weak`] to detect drop of every `Punnu<T>` clone
+    /// — when the strong count of `PunnuInner<T>` falls to zero,
+    /// the upgrade fails, and the loop exits cleanly. No explicit
+    /// shutdown handle.
+    ///
     /// # Panics
     ///
     /// Panics if `config.lru_size == 0` — a zero-capacity LRU is a
@@ -366,15 +446,40 @@ impl<T: Cacheable> PunnuBuilder<T> {
                  a zero-capacity LRU evicts every insert immediately"
             )
         });
+        let sweep_interval = self.config.ttl_sweep_interval;
         let (events, _) = broadcast::channel(self.config.event_channel_capacity);
-        Punnu {
-            inner: Arc::new(PunnuInner {
-                map: RwLock::new(LruCache::new(cap)),
-                events,
-                config: self.config,
-            }),
-        }
+        let inner = Arc::new(PunnuInner {
+            map: RwLock::new(LruCache::new(cap)),
+            events,
+            config: self.config,
+        });
+
+        // Spawn the sweep before constructing the public handle so
+        // the weak ref is captured against the same `Arc` we hand
+        // back. With `runtime-tokio` off, the call site is a no-op.
+        spawn_sweep_if_configured(&inner, sweep_interval);
+
+        Punnu { inner }
     }
+}
+
+/// Spawn the TTL-sweep task when both the feature is enabled and the
+/// config requested a sweep interval. Pulled out of `build()` so the
+/// `cfg` gate is a single statement instead of branching the body.
+#[cfg(feature = "runtime-tokio")]
+fn spawn_sweep_if_configured<T: Cacheable>(inner: &Arc<PunnuInner<T>>, interval: Option<Duration>) {
+    if let Some(interval) = interval {
+        spawn_sweep(Arc::downgrade(inner), interval);
+    }
+}
+
+/// No-op when the `runtime-tokio` feature is off — the sweep cannot
+/// run without a runtime. Lazy expiry on `get` still works.
+#[cfg(not(feature = "runtime-tokio"))]
+fn spawn_sweep_if_configured<T: Cacheable>(
+    _inner: &Arc<PunnuInner<T>>,
+    _interval: Option<Duration>,
+) {
 }
 
 impl<T: Cacheable> Default for PunnuBuilder<T> {

--- a/sassi/src/punnu/tenant.rs
+++ b/sassi/src/punnu/tenant.rs
@@ -1,0 +1,81 @@
+//! [`TenantKey`] — multi-tenant identity for [`crate::punnu::Punnu`]
+//! instances.
+//!
+//! v0.1 of this cluster ships the type alone; cross-tenant access
+//! guards (Doctrine C in spec §3.1.1) wire up alongside the scope /
+//! orchestrator surface in a later task.
+//!
+//! Sassi's tenant model is "tenant identity is part of the cache key" —
+//! materialised by **namespacing the `Punnu` instance**, not by adding
+//! a tenant column inside the cached value. Doctrine C: a
+//! single-tenant `Punnu` and a per-tenant `Punnu` are different types
+//! at construction. The pair `(TenantKey, Punnu<T>)` is the canonical
+//! shape; consumers carry the tenant key alongside the pool reference
+//! and never thread it through `T`.
+
+/// Opaque tenant identifier.
+///
+/// A `TenantKey` is just a wrapper around `String` — no parsing, no
+/// schema. Sassi never inspects the contents; it's a label that flows
+/// through the cache-key namespace and (in a later task) the
+/// cross-tenant access guards. Consumers choose the encoding —
+/// typical patterns are tenant slugs (`"acme"`), HeerId-rendered ids
+/// (`"H7K..."`), or environment-prefixed combos (`"prod_acme"`).
+///
+/// # Construction
+///
+/// Use the standard `From<String>` / `From<&str>` impls, or
+/// [`TenantKey::none`] for the "single-tenant pool" sentinel.
+///
+/// ```
+/// use sassi::TenantKey;
+///
+/// let acme: TenantKey = "acme".into();
+/// assert_eq!(acme.as_str(), "acme");
+/// assert!(TenantKey::none().is_none());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TenantKey(String);
+
+impl TenantKey {
+    /// Construct from anything that converts into a `String`.
+    pub fn new(key: impl Into<String>) -> Self {
+        Self(key.into())
+    }
+
+    /// Sentinel for "no tenant" — equivalent to a single-tenant pool.
+    /// Returns `None` so the caller can branch on tenancy without
+    /// constructing a placeholder string.
+    pub fn none() -> Option<Self> {
+        None
+    }
+
+    /// Borrow the underlying string. Useful for cache-key composition
+    /// and for diagnostics.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Move the underlying string out of the wrapper.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl From<String> for TenantKey {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for TenantKey {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl std::fmt::Display for TenantKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/sassi/src/punnu/ttl.rs
+++ b/sassi/src/punnu/ttl.rs
@@ -53,8 +53,9 @@ use std::sync::Arc;
 use std::sync::Weak;
 // `tokio::time::Instant` is a drop-in for `std::time::Instant` that
 // honours `tokio::time::pause()` / `advance()` in tests. Production
-// behaviour is identical (wall-clock semantics); test code that opts
-// into `#[tokio::test(start_paused = true)]` gets deterministic
+// behaviour is identical — both types read the system monotonic clock
+// outside of `pause()`; test code that opts into
+// `#[tokio::test(start_paused = true)]` gets deterministic
 // virtual-time control over sassi's TTL bookkeeping. Tokio's `time`
 // feature is unconditionally enabled in the workspace, so this import
 // works for both `runtime-tokio` and the no-default-features build.
@@ -175,7 +176,7 @@ pub(crate) fn spawn_sweep<T: Cacheable>(weak: Weak<PunnuInner<T>>, interval: std
             for id in expired_ids {
                 let _ = inner.events.send(PunnuEvent::Invalidate {
                     id,
-                    reason: EventReason::TtlExpired,
+                    reason: EventReason::TtlExpired(crate::punnu::events::Internal::new()),
                 });
             }
         }

--- a/sassi/src/punnu/ttl.rs
+++ b/sassi/src/punnu/ttl.rs
@@ -176,7 +176,7 @@ pub(crate) fn spawn_sweep<T: Cacheable>(weak: Weak<PunnuInner<T>>, interval: std
             for id in expired_ids {
                 let _ = inner.events.send(PunnuEvent::Invalidate {
                     id,
-                    reason: EventReason::TtlExpired(crate::punnu::events::Internal::new()),
+                    reason: EventReason::TtlExpired,
                 });
             }
         }

--- a/sassi/src/punnu/ttl.rs
+++ b/sassi/src/punnu/ttl.rs
@@ -45,13 +45,20 @@
 #[cfg(feature = "runtime-tokio")]
 use crate::cacheable::Cacheable;
 #[cfg(feature = "runtime-tokio")]
-use crate::punnu::events::{InvalidationReason, PunnuEvent};
+use crate::punnu::events::{EventReason, PunnuEvent};
 #[cfg(feature = "runtime-tokio")]
 use crate::punnu::pool::PunnuInner;
 use std::sync::Arc;
 #[cfg(feature = "runtime-tokio")]
 use std::sync::Weak;
-use std::time::Instant;
+// `tokio::time::Instant` is a drop-in for `std::time::Instant` that
+// honours `tokio::time::pause()` / `advance()` in tests. Production
+// behaviour is identical (wall-clock semantics); test code that opts
+// into `#[tokio::test(start_paused = true)]` gets deterministic
+// virtual-time control over sassi's TTL bookkeeping. Tokio's `time`
+// feature is unconditionally enabled in the workspace, so this import
+// works for both `runtime-tokio` and the no-default-features build.
+use tokio::time::Instant;
 
 /// LRU storage cell — holds the cached payload plus per-entry
 /// metadata.
@@ -63,8 +70,11 @@ pub(crate) struct Entry<T> {
     pub value: Arc<T>,
 
     /// Absolute expiry deadline, computed from
-    /// `Instant::now() + ttl` at insert time. `None` means the entry
-    /// never expires on time (LRU eviction can still drop it).
+    /// `tokio::time::Instant::now() + ttl` at insert time. `None`
+    /// means the entry never expires on time (LRU eviction can still
+    /// drop it). `tokio::time::Instant` is a drop-in for
+    /// `std::time::Instant` that honours `tokio::time::pause` in
+    /// tests; production wall-clock semantics are unchanged.
     pub expires_at: Option<Instant>,
 }
 
@@ -116,10 +126,11 @@ impl<T> Clone for Entry<T> {
 /// cleanly. No explicit handle, no `JoinHandle` to drop, no
 /// `Notify` — the cancellation primitive is owner-loss itself.
 ///
-/// The executor abstraction lands in a later task; until then, the
-/// sweep is hard-coded to `tokio::spawn`. WASM consumers that opt
-/// in to TTL with `ttl_sweep_interval = Some(_)` will need the
-/// executor refactor.
+/// Direct `tokio::spawn` here is wasm-incompatible; refactored
+/// through `PunnuExecutor` in Cluster B, Task 10. WASM consumers
+/// that opt in to TTL with `ttl_sweep_interval = Some(_)` need that
+/// executor abstraction. Tracked at
+/// <https://github.com/TarunvirBains/sassi/issues/3>.
 #[cfg(feature = "runtime-tokio")]
 pub(crate) fn spawn_sweep<T: Cacheable>(weak: Weak<PunnuInner<T>>, interval: std::time::Duration) {
     tokio::spawn(async move {
@@ -164,7 +175,7 @@ pub(crate) fn spawn_sweep<T: Cacheable>(weak: Weak<PunnuInner<T>>, interval: std
             for id in expired_ids {
                 let _ = inner.events.send(PunnuEvent::Invalidate {
                     id,
-                    reason: InvalidationReason::TtlExpired,
+                    reason: EventReason::TtlExpired,
                 });
             }
         }

--- a/sassi/src/punnu/ttl.rs
+++ b/sassi/src/punnu/ttl.rs
@@ -3,9 +3,32 @@
 //! The internal LRU map stores [`Entry<T>`] rather than `Arc<T>`
 //! directly so per-entry metadata (currently just `expires_at`) lives
 //! alongside the value. Consumers never see `Entry<T>` — `Punnu`
-//! returns `Arc<T>` from `get` / `insert`. Task 4 introduces the type;
-//! Task 6 wires `expires_at` into the lazy-expiry and background
-//! sweep paths.
+//! returns `Arc<T>` from `get` / `insert`. The storage shape
+//! ([`Entry<T>`] with `expires_at: Option<Instant>`) lands alongside
+//! the pool itself; the lazy-expiry behaviour and the background
+//! sweep that act on `expires_at` live in this module too.
+//!
+//! # TTL semantics (spec §6.2.5)
+//!
+//! Two mechanisms enforce expiry:
+//!
+//! - **Lazy expiry on access.** Always active. [`Punnu::get`] checks
+//!   `expires_at <= Instant::now()`; if expired, removes the entry
+//!   from L1 and emits `PunnuEvent::Invalidate { reason: TtlExpired
+//!   }`. Cost: one comparison per `get`.
+//! - **Background sweep.** Active iff
+//!   [`crate::punnu::PunnuConfig::ttl_sweep_interval`] is `Some`. Walks
+//!   the L1 every interval tick, removes anything already expired,
+//!   emits `TtlExpired` for each. Bounded O(n) per tick where n is
+//!   the entry count; the sweep takes the L1 write lock briefly. Off
+//!   by default — only worth running when the access pattern leaves
+//!   long-tail expired entries lingering in storage and the metrics
+//!   layer or downstream subscribers rely on prompt removal.
+//!
+//! Interaction with other invalidation paths is documented in the
+//! spec; the short version: independent of LRU and save/delete; same
+//! reason discriminator (`TtlExpired`) regardless of which mechanism
+//! observes the expiry first.
 //!
 //! # Why an internal struct rather than a tuple?
 //!
@@ -19,7 +42,15 @@
 //!   payload is `Arc<T>`; `Instant` is `Copy`. Cloning happens
 //!   on every `get` returning a sharable handle.
 
+#[cfg(feature = "runtime-tokio")]
+use crate::cacheable::Cacheable;
+#[cfg(feature = "runtime-tokio")]
+use crate::punnu::events::{InvalidationReason, PunnuEvent};
+#[cfg(feature = "runtime-tokio")]
+use crate::punnu::pool::PunnuInner;
 use std::sync::Arc;
+#[cfg(feature = "runtime-tokio")]
+use std::sync::Weak;
 use std::time::Instant;
 
 /// LRU storage cell — holds the cached payload plus per-entry
@@ -38,15 +69,31 @@ pub(crate) struct Entry<T> {
 }
 
 impl<T> Entry<T> {
-    /// Construct an entry with no TTL. Convenience helper used by the
-    /// vast majority of inserts (default config has `default_ttl =
-    /// None`). The TTL-aware `with_expiry` / `is_expired_at` helpers
-    /// land alongside the lazy-expiry behaviour in the next task.
-    pub(crate) fn new(value: Arc<T>) -> Self {
-        Self {
-            value,
-            expires_at: None,
+    /// Construct an entry with an explicit expiry deadline. `None`
+    /// means the entry never expires on time (LRU eviction is the
+    /// only way for it to leave the cache).
+    pub(crate) fn with_expiry(value: Arc<T>, expires_at: Option<Instant>) -> Self {
+        Self { value, expires_at }
+    }
+
+    /// Has the entry's TTL elapsed against `now`?
+    ///
+    /// Pure (no clock read) so callers can sample `Instant::now()`
+    /// once per sweep tick and reuse it across many entries — the
+    /// background sweep does exactly this.
+    pub(crate) fn is_expired_at(&self, now: Instant) -> bool {
+        match self.expires_at {
+            Some(deadline) => deadline <= now,
+            None => false,
         }
+    }
+
+    /// Has the entry's TTL elapsed against the current clock?
+    /// Convenience wrapper around `is_expired_at(Instant::now())` for
+    /// the lazy-expiry path on `get`, where there's no batched clock
+    /// to reuse.
+    pub(crate) fn is_expired(&self) -> bool {
+        self.is_expired_at(Instant::now())
     }
 }
 
@@ -59,4 +106,67 @@ impl<T> Clone for Entry<T> {
             expires_at: self.expires_at,
         }
     }
+}
+
+/// Spawn the background sweep task on the tokio runtime.
+///
+/// Cancellation is handled via the [`Weak`] reference: when every
+/// `Punnu<T>` clone drops, the strong count of `PunnuInner<T>` falls
+/// to zero, `weak.upgrade()` returns `None`, and the loop exits
+/// cleanly. No explicit handle, no `JoinHandle` to drop, no
+/// `Notify` — the cancellation primitive is owner-loss itself.
+///
+/// The executor abstraction lands in a later task; until then, the
+/// sweep is hard-coded to `tokio::spawn`. WASM consumers that opt
+/// in to TTL with `ttl_sweep_interval = Some(_)` will need the
+/// executor refactor.
+#[cfg(feature = "runtime-tokio")]
+pub(crate) fn spawn_sweep<T: Cacheable>(weak: Weak<PunnuInner<T>>, interval: std::time::Duration) {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(interval);
+        // Skip the first immediate tick — `interval` fires once at t=0
+        // by default, which would sweep before any insert lands.
+        // `Burst` is the default `MissedTickBehavior` and is fine
+        // here; we just prefer to start the cadence at +interval.
+        tick.tick().await;
+        loop {
+            tick.tick().await;
+
+            // Upgrade once per tick. If every Punnu<T> clone has
+            // dropped, the inner is gone and we exit cleanly.
+            let Some(inner) = weak.upgrade() else { break };
+
+            // Scope the lock so we drop it before broadcasting the
+            // events — the broadcast send is non-blocking but should
+            // still not extend lock-hold time.
+            let expired_ids: Vec<T::Id> = {
+                let mut map = match inner.map.write() {
+                    Ok(guard) => guard,
+                    // Lock poisoning means a previous panic left the
+                    // map in an inconsistent state. The sweep can't
+                    // do anything useful in that case; bail out. The
+                    // public API surface returns the same poison.
+                    Err(_) => break,
+                };
+                let now = Instant::now();
+                let mut to_remove = Vec::new();
+                for (id, entry) in map.iter() {
+                    if entry.is_expired_at(now) {
+                        to_remove.push(id.clone());
+                    }
+                }
+                for id in &to_remove {
+                    map.pop(id);
+                }
+                to_remove
+            };
+
+            for id in expired_ids {
+                let _ = inner.events.send(PunnuEvent::Invalidate {
+                    id,
+                    reason: InvalidationReason::TtlExpired,
+                });
+            }
+        }
+    });
 }

--- a/sassi/src/punnu/ttl.rs
+++ b/sassi/src/punnu/ttl.rs
@@ -1,0 +1,62 @@
+//! Storage entry layout + TTL helpers.
+//!
+//! The internal LRU map stores [`Entry<T>`] rather than `Arc<T>`
+//! directly so per-entry metadata (currently just `expires_at`) lives
+//! alongside the value. Consumers never see `Entry<T>` — `Punnu`
+//! returns `Arc<T>` from `get` / `insert`. Task 4 introduces the type;
+//! Task 6 wires `expires_at` into the lazy-expiry and background
+//! sweep paths.
+//!
+//! # Why an internal struct rather than a tuple?
+//!
+//! - **Forward compatibility:** later metadata (per-entry `inserted_at`
+//!   for refresh hints, per-entry `tenant_origin` for cross-tenant
+//!   guard diagnostics, …) lands without changing every callsite.
+//! - **Discoverability:** `entry.is_expired()` reads better than
+//!   `entry.1.map(|t| t <= Instant::now()).unwrap_or(false)` and keeps
+//!   the comparison policy in one place.
+//! - **Clone semantics:** `Entry<T>: Clone` cheaply because the
+//!   payload is `Arc<T>`; `Instant` is `Copy`. Cloning happens
+//!   on every `get` returning a sharable handle.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+/// LRU storage cell — holds the cached payload plus per-entry
+/// metadata.
+///
+/// `pub(crate)` because `Punnu` returns `Arc<T>` from `get`; the
+/// metadata is internal bookkeeping.
+pub(crate) struct Entry<T> {
+    /// Shared handle to the cached payload.
+    pub value: Arc<T>,
+
+    /// Absolute expiry deadline, computed from
+    /// `Instant::now() + ttl` at insert time. `None` means the entry
+    /// never expires on time (LRU eviction can still drop it).
+    pub expires_at: Option<Instant>,
+}
+
+impl<T> Entry<T> {
+    /// Construct an entry with no TTL. Convenience helper used by the
+    /// vast majority of inserts (default config has `default_ttl =
+    /// None`). The TTL-aware `with_expiry` / `is_expired_at` helpers
+    /// land alongside the lazy-expiry behaviour in the next task.
+    pub(crate) fn new(value: Arc<T>) -> Self {
+        Self {
+            value,
+            expires_at: None,
+        }
+    }
+}
+
+// Manual `Clone`: deriving would require `T: Clone` even though the
+// only data field is `Arc<T>` (which is `Clone` regardless of `T`).
+impl<T> Clone for Entry<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            expires_at: self.expires_at,
+        }
+    }
+}

--- a/sassi/tests/punnu_events.rs
+++ b/sassi/tests/punnu_events.rs
@@ -163,7 +163,7 @@ async fn lru_evict_fires_invalidate_event() {
         match ev {
             PunnuEvent::Invalidate {
                 id: 1,
-                reason: EventReason::LruEvict,
+                reason: EventReason::LruEvict(_),
             } => saw_evict = true,
             PunnuEvent::Insert { value } if value.id == 1 => saw_insert_1 = true,
             PunnuEvent::Insert { value } if value.id == 2 => saw_insert_2 = true,
@@ -196,7 +196,7 @@ async fn lru_evict_event_orders_before_insert_event_for_new_entry() {
         matches!(
             first,
             PunnuEvent::Invalidate {
-                reason: EventReason::LruEvict,
+                reason: EventReason::LruEvict(_),
                 ..
             }
         ),

--- a/sassi/tests/punnu_events.rs
+++ b/sassi/tests/punnu_events.rs
@@ -163,7 +163,7 @@ async fn lru_evict_fires_invalidate_event() {
         match ev {
             PunnuEvent::Invalidate {
                 id: 1,
-                reason: EventReason::LruEvict(_),
+                reason: EventReason::LruEvict { .. },
             } => saw_evict = true,
             PunnuEvent::Insert { value } if value.id == 1 => saw_insert_1 = true,
             PunnuEvent::Insert { value } if value.id == 2 => saw_insert_2 = true,
@@ -196,7 +196,7 @@ async fn lru_evict_event_orders_before_insert_event_for_new_entry() {
         matches!(
             first,
             PunnuEvent::Invalidate {
-                reason: EventReason::LruEvict(_),
+                reason: EventReason::LruEvict { .. },
                 ..
             }
         ),

--- a/sassi/tests/punnu_events.rs
+++ b/sassi/tests/punnu_events.rs
@@ -1,0 +1,262 @@
+//! Task 5 — `Punnu<T>` event stream coverage.
+//!
+//! Exercises the four event-related contracts:
+//!
+//! - `insert` emits [`PunnuEvent::Insert`]
+//! - `invalidate` emits [`PunnuEvent::Invalidate`] carrying the supplied
+//!   [`InvalidationReason`]
+//! - LRU eviction emits [`PunnuEvent::Invalidate { reason: LruEvict }`]
+//! - The channel is **lossy under load** — a slow subscriber sees
+//!   `RecvError::Lagged` rather than crashing the producer (spec §3.5
+//!   lossy-by-design contract)
+//!
+//! Implementation lives in Task 4 (`pool.rs`); this file is the
+//! observability test surface.
+
+use sassi::{Cacheable, Field, InvalidationReason, OnConflict, Punnu, PunnuConfig, PunnuEvent};
+use tokio::sync::broadcast::error::TryRecvError;
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+    label: &'static str,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+    #[allow(dead_code)]
+    label: Field<E, &'static str>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+}
+
+#[tokio::test]
+async fn insert_emits_insert_event() {
+    let p = Punnu::<E>::builder().build();
+    let mut rx = p.events();
+    p.insert(E { id: 1, label: "a" }).await.unwrap();
+
+    match rx.try_recv().expect("expected an Insert event") {
+        PunnuEvent::Insert { value } => {
+            assert_eq!(value.id, 1);
+            assert_eq!(value.label, "a");
+        }
+        other => panic!("expected PunnuEvent::Insert, got {other:?}"),
+    }
+    // Stream should be drained — no spurious follow-up events.
+    assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn replace_under_last_write_wins_emits_insert_not_update() {
+    // Default OnConflict is LastWriteWins, which emits Insert (not
+    // Update) on replace — Update is a separate opt-in policy.
+    let p = Punnu::<E>::builder().build();
+    p.insert(E { id: 1, label: "v1" }).await.unwrap();
+    let mut rx = p.events();
+    p.insert(E { id: 1, label: "v2" }).await.unwrap();
+
+    match rx.try_recv().expect("expected Insert (LastWriteWins)") {
+        PunnuEvent::Insert { value } => assert_eq!(value.label, "v2"),
+        other => panic!("expected PunnuEvent::Insert, got {other:?}"),
+    }
+    // No invalidate event for the replaced entry — replace is a single
+    // logical operation, not delete+insert.
+    assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn replace_under_on_conflict_update_emits_update_event() {
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            on_conflict: OnConflict::Update,
+            ..Default::default()
+        })
+        .build();
+    p.insert(E {
+        id: 1,
+        label: "old",
+    })
+    .await
+    .unwrap();
+    let mut rx = p.events();
+    p.insert(E {
+        id: 1,
+        label: "new",
+    })
+    .await
+    .unwrap();
+
+    match rx.try_recv().expect("expected Update event") {
+        PunnuEvent::Update { old, new } => {
+            assert_eq!(old.label, "old");
+            assert_eq!(new.label, "new");
+        }
+        other => panic!("expected PunnuEvent::Update, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn invalidate_emits_invalidate_with_reason() {
+    let p = Punnu::<E>::builder().build();
+    p.insert(E { id: 1, label: "a" }).await.unwrap();
+    let mut rx = p.events();
+
+    p.invalidate(&1, InvalidationReason::Manual).await;
+    match rx.try_recv().expect("expected Invalidate event") {
+        PunnuEvent::Invalidate { id, reason } => {
+            assert_eq!(id, 1);
+            assert_eq!(reason, InvalidationReason::Manual);
+        }
+        other => panic!("expected PunnuEvent::Invalidate, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn invalidate_unknown_id_emits_no_event() {
+    // Idempotency: invalidating a missing id is a no-op — and a no-op
+    // must not produce a phantom event (subscribers that count
+    // invalidations would otherwise overcount).
+    let p = Punnu::<E>::builder().build();
+    let mut rx = p.events();
+    p.invalidate(&42, InvalidationReason::Manual).await;
+    assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn lru_evict_fires_invalidate_event() {
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            lru_size: 1,
+            ..Default::default()
+        })
+        .build();
+    let mut rx = p.events();
+    p.insert(E { id: 1, label: "a" }).await.unwrap();
+    p.insert(E { id: 2, label: "b" }).await.unwrap();
+
+    // Drain everything we received and look for the eviction event.
+    // Capacity-1 + two inserts must produce exactly one LruEvict for
+    // id=1 plus two Insert events.
+    let mut saw_evict = false;
+    let mut saw_insert_1 = false;
+    let mut saw_insert_2 = false;
+    while let Ok(ev) = rx.try_recv() {
+        match ev {
+            PunnuEvent::Invalidate {
+                id: 1,
+                reason: InvalidationReason::LruEvict,
+            } => saw_evict = true,
+            PunnuEvent::Insert { value } if value.id == 1 => saw_insert_1 = true,
+            PunnuEvent::Insert { value } if value.id == 2 => saw_insert_2 = true,
+            other => panic!("unexpected event in lru-evict test: {other:?}"),
+        }
+    }
+    assert!(saw_evict, "expected LruEvict event for id=1");
+    assert!(saw_insert_1, "expected Insert event for id=1");
+    assert!(saw_insert_2, "expected Insert event for id=2");
+}
+
+#[tokio::test]
+async fn lru_evict_event_orders_before_insert_event_for_new_entry() {
+    // Spec semantic: the eviction "happened first" to make room.
+    // Subscribers that build distributed-cache invalidation streams
+    // depend on this ordering.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            lru_size: 1,
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1, label: "a" }).await.unwrap();
+    let mut rx = p.events(); // subscribe AFTER id=1 so we don't see its insert
+    p.insert(E { id: 2, label: "b" }).await.unwrap();
+
+    let first = rx.try_recv().expect("first event");
+    let second = rx.try_recv().expect("second event");
+    assert!(
+        matches!(
+            first,
+            PunnuEvent::Invalidate {
+                reason: InvalidationReason::LruEvict,
+                ..
+            }
+        ),
+        "first event must be the LRU eviction; got {first:?}"
+    );
+    assert!(
+        matches!(second, PunnuEvent::Insert { ref value } if value.id == 2),
+        "second event must be the new insert; got {second:?}"
+    );
+}
+
+#[tokio::test]
+async fn lossy_when_subscriber_lags_does_not_crash_producer() {
+    // Lossy-by-design: when a subscriber falls behind the channel
+    // capacity, the broadcast channel drops the oldest events for
+    // that subscriber and surfaces RecvError::Lagged. The producer
+    // never blocks. This is the spec §3.5 lossy contract.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            lru_size: 1024,
+            event_channel_capacity: 4,
+            ..Default::default()
+        })
+        .build();
+    let mut rx = p.events();
+    for i in 0..100 {
+        // Producer must not block / panic / error even though the
+        // subscriber never drains.
+        p.insert(E { id: i, label: "x" }).await.unwrap();
+    }
+
+    // Drain whatever the subscriber sees; we must observe a Lagged
+    // error at least once given the 4-cap channel and 100 events.
+    let mut saw_lagged = false;
+    let mut events_drained = 0;
+    loop {
+        match rx.try_recv() {
+            Ok(_) => events_drained += 1,
+            Err(TryRecvError::Lagged(_)) => {
+                saw_lagged = true;
+                // Continue draining — Lagged just signals "we skipped
+                // forward in the queue"; receiver is still usable.
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Closed) => panic!("channel closed unexpectedly"),
+        }
+    }
+    assert!(
+        saw_lagged,
+        "expected RecvError::Lagged given 100 events into a 4-capacity channel"
+    );
+    // Exact count is non-deterministic (depends on scheduling), but
+    // the channel capacity is the upper bound on pending events.
+    assert!(
+        events_drained <= 4,
+        "channel capacity is 4, so we cannot drain more than 4 buffered events at any moment; \
+         drained {events_drained}"
+    );
+    // And the cache itself stayed healthy throughout.
+    assert_eq!(p.len(), 100);
+}
+
+#[tokio::test]
+async fn no_active_subscribers_does_not_break_insert() {
+    // broadcast::Sender::send returns Err(SendError) when there are
+    // zero active receivers. Punnu must swallow that gracefully —
+    // events are observability, not a correctness boundary.
+    let p = Punnu::<E>::builder().build();
+    // No call to events() — zero subscribers.
+    p.insert(E { id: 1, label: "a" }).await.unwrap();
+    p.invalidate(&1, InvalidationReason::Manual).await;
+    assert_eq!(p.len(), 0);
+}

--- a/sassi/tests/punnu_events.rs
+++ b/sassi/tests/punnu_events.rs
@@ -13,7 +13,9 @@
 //! Implementation lives in Task 4 (`pool.rs`); this file is the
 //! observability test surface.
 
-use sassi::{Cacheable, Field, InvalidationReason, OnConflict, Punnu, PunnuConfig, PunnuEvent};
+use sassi::{
+    Cacheable, EventReason, Field, InvalidationReason, OnConflict, Punnu, PunnuConfig, PunnuEvent,
+};
 use tokio::sync::broadcast::error::TryRecvError;
 
 #[derive(Debug, Clone)]
@@ -35,6 +37,12 @@ impl Cacheable for E {
     type Fields = EFields;
     fn id(&self) -> i64 {
         self.id
+    }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+            label: Field::new("label", |e| &e.label),
+        }
     }
 }
 
@@ -114,7 +122,9 @@ async fn invalidate_emits_invalidate_with_reason() {
     match rx.try_recv().expect("expected Invalidate event") {
         PunnuEvent::Invalidate { id, reason } => {
             assert_eq!(id, 1);
-            assert_eq!(reason, InvalidationReason::Manual);
+            // Public `Manual` lifts into the wider taxonomy as
+            // `EventReason::Manual` on the event stream.
+            assert_eq!(reason, EventReason::Manual);
         }
         other => panic!("expected PunnuEvent::Invalidate, got {other:?}"),
     }
@@ -153,7 +163,7 @@ async fn lru_evict_fires_invalidate_event() {
         match ev {
             PunnuEvent::Invalidate {
                 id: 1,
-                reason: InvalidationReason::LruEvict,
+                reason: EventReason::LruEvict,
             } => saw_evict = true,
             PunnuEvent::Insert { value } if value.id == 1 => saw_insert_1 = true,
             PunnuEvent::Insert { value } if value.id == 2 => saw_insert_2 = true,
@@ -186,7 +196,7 @@ async fn lru_evict_event_orders_before_insert_event_for_new_entry() {
         matches!(
             first,
             PunnuEvent::Invalidate {
-                reason: InvalidationReason::LruEvict,
+                reason: EventReason::LruEvict,
                 ..
             }
         ),

--- a/sassi/tests/punnu_identity_map.rs
+++ b/sassi/tests/punnu_identity_map.rs
@@ -1,0 +1,255 @@
+//! Task 4 — `Punnu<T>` identity-map basics: insert, get, invalidate,
+//! LRU eviction.
+//!
+//! Each test hand-writes the [`sassi::Cacheable`] impl rather than
+//! reaching for the derive macro — predicate filtering is not the
+//! focus of this cluster, and the hand-impl path needs to keep
+//! working anyway (spec §3.1 docs the contract for adopters who
+//! can't or don't want to use the derive).
+
+use sassi::{Cacheable, Field, InvalidationReason, OnConflict, Punnu, PunnuConfig};
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+struct Item {
+    id: i64,
+    name: String,
+}
+
+#[derive(Default)]
+struct ItemFields {
+    #[allow(dead_code)]
+    id: Field<Item, i64>,
+    #[allow(dead_code)]
+    name: Field<Item, String>,
+}
+
+impl Cacheable for Item {
+    type Id = i64;
+    type Fields = ItemFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+}
+
+#[tokio::test]
+async fn insert_and_get_round_trip() {
+    let punnu = Punnu::<Item>::builder().build();
+    let inserted: Arc<Item> = punnu
+        .insert(Item {
+            id: 1,
+            name: "a".into(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(inserted.id, 1);
+    assert_eq!(inserted.name, "a");
+
+    let fetched = punnu.get(&1).expect("entry should be cached");
+    assert_eq!(fetched.id, 1);
+    assert_eq!(fetched.name, "a");
+    assert_eq!(punnu.len(), 1);
+    assert!(!punnu.is_empty());
+}
+
+#[tokio::test]
+async fn last_write_wins_replaces_entry() {
+    let punnu = Punnu::<Item>::builder().build();
+    punnu
+        .insert(Item {
+            id: 1,
+            name: "v1".into(),
+        })
+        .await
+        .unwrap();
+    punnu
+        .insert(Item {
+            id: 1,
+            name: "v2".into(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(punnu.get(&1).unwrap().name, "v2");
+    // Identity-map invariant: replace doesn't grow the map.
+    assert_eq!(punnu.len(), 1);
+}
+
+#[tokio::test]
+async fn invalidate_drops_entry() {
+    let punnu = Punnu::<Item>::builder().build();
+    punnu
+        .insert(Item {
+            id: 1,
+            name: "x".into(),
+        })
+        .await
+        .unwrap();
+    assert!(punnu.get(&1).is_some());
+
+    punnu.invalidate(&1, InvalidationReason::Manual).await;
+    assert!(punnu.get(&1).is_none());
+    assert_eq!(punnu.len(), 0);
+    assert!(punnu.is_empty());
+}
+
+#[tokio::test]
+async fn invalidate_unknown_id_is_noop() {
+    // Idempotency: invalidating a missing id must not panic, must
+    // not error, and must not produce an event (the test for the
+    // "no event" half lives in `punnu_events.rs`; the "no panic"
+    // half is here).
+    let punnu = Punnu::<Item>::builder().build();
+    punnu.invalidate(&999, InvalidationReason::Manual).await;
+    assert_eq!(punnu.len(), 0);
+}
+
+#[tokio::test]
+async fn lru_eviction_at_capacity() {
+    let punnu = Punnu::<Item>::builder()
+        .config(PunnuConfig {
+            lru_size: 2,
+            ..Default::default()
+        })
+        .build();
+    punnu
+        .insert(Item {
+            id: 1,
+            name: "a".into(),
+        })
+        .await
+        .unwrap();
+    punnu
+        .insert(Item {
+            id: 2,
+            name: "b".into(),
+        })
+        .await
+        .unwrap();
+    punnu
+        .insert(Item {
+            id: 3,
+            name: "c".into(),
+        })
+        .await
+        .unwrap();
+
+    // Item 1 was the least-recently-used at the time item 3 landed.
+    assert!(punnu.get(&1).is_none(), "id 1 should have been LRU-evicted");
+    assert!(punnu.get(&2).is_some());
+    assert!(punnu.get(&3).is_some());
+    assert_eq!(punnu.len(), 2);
+}
+
+#[tokio::test]
+async fn lru_get_refreshes_recency() {
+    // After touching id 1 via `get`, the next insert at capacity
+    // should evict id 2 (now LRU) rather than id 1.
+    let punnu = Punnu::<Item>::builder()
+        .config(PunnuConfig {
+            lru_size: 2,
+            ..Default::default()
+        })
+        .build();
+    punnu
+        .insert(Item {
+            id: 1,
+            name: "a".into(),
+        })
+        .await
+        .unwrap();
+    punnu
+        .insert(Item {
+            id: 2,
+            name: "b".into(),
+        })
+        .await
+        .unwrap();
+
+    let _ = punnu.get(&1); // refresh recency
+
+    punnu
+        .insert(Item {
+            id: 3,
+            name: "c".into(),
+        })
+        .await
+        .unwrap();
+
+    assert!(punnu.get(&1).is_some(), "id 1 was just touched");
+    assert!(
+        punnu.get(&2).is_none(),
+        "id 2 should now be the LRU candidate"
+    );
+    assert!(punnu.get(&3).is_some());
+}
+
+#[tokio::test]
+async fn on_conflict_reject_returns_error_and_keeps_existing() {
+    let punnu = Punnu::<Item>::builder()
+        .config(PunnuConfig {
+            on_conflict: OnConflict::Reject,
+            ..Default::default()
+        })
+        .build();
+    punnu
+        .insert(Item {
+            id: 1,
+            name: "first".into(),
+        })
+        .await
+        .unwrap();
+
+    let err = punnu
+        .insert(Item {
+            id: 1,
+            name: "second".into(),
+        })
+        .await
+        .expect_err("Reject must surface a Conflict on duplicate id");
+    assert!(matches!(err, sassi::InsertError::Conflict));
+
+    assert_eq!(
+        punnu.get(&1).unwrap().name,
+        "first",
+        "rejected insert must not overwrite"
+    );
+}
+
+#[test]
+fn clones_share_state() {
+    // `Punnu<T>` is `Clone` and observes the same identity map across
+    // clones — this is the intended sharing pattern.
+    let punnu_a = Punnu::<Item>::builder().build();
+    let punnu_b = punnu_a.clone();
+
+    // Use the runtime in a contained block so the `#[test]` (sync)
+    // doesn't fight `#[tokio::test]`.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        punnu_a
+            .insert(Item {
+                id: 7,
+                name: "z".into(),
+            })
+            .await
+            .unwrap();
+    });
+
+    assert!(punnu_b.get(&7).is_some(), "clone must observe the insert");
+    assert_eq!(punnu_b.len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "PunnuConfig::lru_size must be non-zero")]
+fn build_panics_on_zero_lru_size() {
+    let _ = Punnu::<Item>::builder()
+        .config(PunnuConfig {
+            lru_size: 0,
+            ..Default::default()
+        })
+        .build();
+}

--- a/sassi/tests/punnu_identity_map.rs
+++ b/sassi/tests/punnu_identity_map.rs
@@ -30,6 +30,12 @@ impl Cacheable for Item {
     fn id(&self) -> i64 {
         self.id
     }
+    fn fields() -> ItemFields {
+        ItemFields {
+            id: Field::new("id", |i| &i.id),
+            name: Field::new("name", |i| &i.name),
+        }
+    }
 }
 
 #[tokio::test]
@@ -249,6 +255,35 @@ fn build_panics_on_zero_lru_size() {
     let _ = Punnu::<Item>::builder()
         .config(PunnuConfig {
             lru_size: 0,
+            ..Default::default()
+        })
+        .build();
+}
+
+#[test]
+#[should_panic(expected = "PunnuConfig::ttl_sweep_interval must be greater than Duration::ZERO")]
+fn build_panics_on_zero_ttl_sweep_interval() {
+    // Guard against a `tokio::time::interval(Duration::ZERO)` panic
+    // at sweep-spawn time. The builder catches the bad shape with a
+    // descriptive message; consumers who want "no sweep" must pass
+    // `None`.
+    let _ = Punnu::<Item>::builder()
+        .config(PunnuConfig {
+            ttl_sweep_interval: Some(std::time::Duration::ZERO),
+            ..Default::default()
+        })
+        .build();
+}
+
+#[test]
+#[should_panic(expected = "PunnuConfig::event_channel_capacity must be greater than 0")]
+fn build_panics_on_zero_event_channel_capacity() {
+    // Guard against a `tokio::sync::broadcast::channel(0)` panic at
+    // build time. The builder catches the bad shape and surfaces a
+    // descriptive message instead of the cryptic tokio panic.
+    let _ = Punnu::<Item>::builder()
+        .config(PunnuConfig {
+            event_channel_capacity: 0,
             ..Default::default()
         })
         .build();

--- a/sassi/tests/punnu_ttl_lazy.rs
+++ b/sassi/tests/punnu_ttl_lazy.rs
@@ -5,8 +5,16 @@
 //! a `PunnuEvent::Invalidate { reason: TtlExpired }`. This file
 //! exercises that contract — the background sweep variant lives in
 //! `punnu_ttl_sweep.rs`.
+//!
+//! All tests run under `#[tokio::test(start_paused = true)]` and use
+//! `tokio::time::advance(...)` to drive virtual time forward
+//! deterministically. Sassi's TTL bookkeeping reads
+//! `tokio::time::Instant::now()` (a drop-in for `std::time::Instant`
+//! that honours the paused clock), so virtual-time advancement is
+//! observable to the cache. No real `sleep` calls — the tests are
+//! impervious to CI scheduling jitter.
 
-use sassi::{Cacheable, Field, InvalidationReason, Punnu, PunnuConfig, PunnuEvent};
+use sassi::{Cacheable, EventReason, Field, Punnu, PunnuConfig, PunnuEvent};
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -26,13 +34,18 @@ impl Cacheable for E {
     fn id(&self) -> i64 {
         self.id
     }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+        }
+    }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn ttl_expires_lazily_on_get() {
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            default_ttl: Some(Duration::from_millis(50)),
+            default_ttl: Some(Duration::from_secs(60)),
             ..Default::default()
         })
         .build();
@@ -45,7 +58,7 @@ async fn ttl_expires_lazily_on_get() {
     // Subscribe BEFORE the expiry triggers so we can observe the
     // TtlExpired event without racing.
     let mut rx = p.events();
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    tokio::time::advance(Duration::from_secs(61)).await;
 
     assert!(
         p.get(&1).is_none(),
@@ -57,22 +70,22 @@ async fn ttl_expires_lazily_on_get() {
     match rx.try_recv().expect("expected TtlExpired event") {
         PunnuEvent::Invalidate {
             id: 1,
-            reason: InvalidationReason::TtlExpired,
+            reason: EventReason::TtlExpired,
         } => {}
         other => panic!("expected TtlExpired for id=1, got {other:?}"),
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn no_default_ttl_means_no_expiry() {
     // With `default_ttl = None`, entries should never expire on time.
     let p = Punnu::<E>::builder().build();
     p.insert(E { id: 1 }).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    tokio::time::advance(Duration::from_secs(60)).await;
     assert!(p.get(&1).is_some(), "no TTL configured — entry must remain");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn insert_with_ttl_overrides_config_default() {
     // Per-entry override: even though the pool default is 60s,
     // the explicit insert_with_ttl wins for this entry.
@@ -82,57 +95,57 @@ async fn insert_with_ttl_overrides_config_default() {
             ..Default::default()
         })
         .build();
-    p.insert_with_ttl(E { id: 1 }, Duration::from_millis(50))
+    p.insert_with_ttl(E { id: 1 }, Duration::from_secs(5))
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    tokio::time::advance(Duration::from_secs(6)).await;
     assert!(
         p.get(&1).is_none(),
         "entry-level TTL must override pool default"
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn insert_with_ttl_overrides_when_pool_default_is_none() {
     // Per-entry TTL works even when the pool has no default.
     let p = Punnu::<E>::builder().build();
-    p.insert_with_ttl(E { id: 1 }, Duration::from_millis(50))
+    p.insert_with_ttl(E { id: 1 }, Duration::from_secs(5))
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    tokio::time::advance(Duration::from_secs(6)).await;
     assert!(p.get(&1).is_none());
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn lazy_expiry_decrements_len() {
     // After lazy expiry on get, the entry must be physically gone.
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            default_ttl: Some(Duration::from_millis(40)),
+            default_ttl: Some(Duration::from_secs(5)),
             ..Default::default()
         })
         .build();
     p.insert(E { id: 1 }).await.unwrap();
     assert_eq!(p.len(), 1);
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    tokio::time::advance(Duration::from_secs(6)).await;
     let _ = p.get(&1); // triggers lazy expiry
     assert_eq!(p.len(), 0, "lazy expiry must remove the entry from L1");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn lazy_expiry_event_fires_at_most_once_for_a_given_entry() {
     // Two `get`s after expiry should not produce two TtlExpired
     // events — the first `get` removes the entry; the second `get`
     // observes a miss with no event.
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            default_ttl: Some(Duration::from_millis(40)),
+            default_ttl: Some(Duration::from_secs(5)),
             ..Default::default()
         })
         .build();
     p.insert(E { id: 1 }).await.unwrap();
     let mut rx = p.events();
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    tokio::time::advance(Duration::from_secs(6)).await;
 
     // First get: triggers lazy expiry, emits TtlExpired.
     assert!(p.get(&1).is_none());
@@ -144,7 +157,7 @@ async fn lazy_expiry_event_fires_at_most_once_for_a_given_entry() {
         if matches!(
             ev,
             PunnuEvent::Invalidate {
-                reason: InvalidationReason::TtlExpired,
+                reason: EventReason::TtlExpired,
                 ..
             }
         ) {
@@ -157,11 +170,11 @@ async fn lazy_expiry_event_fires_at_most_once_for_a_given_entry() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn unexpired_get_does_not_emit_ttl_event() {
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            default_ttl: Some(Duration::from_millis(500)),
+            default_ttl: Some(Duration::from_secs(60)),
             ..Default::default()
         })
         .build();
@@ -176,7 +189,7 @@ async fn unexpired_get_does_not_emit_ttl_event() {
     ));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn lazy_expiry_under_concurrent_gets_emits_one_event() {
     // Race condition probe: many concurrent `get` calls for the same
     // expired entry must collectively produce at most one
@@ -185,14 +198,14 @@ async fn lazy_expiry_under_concurrent_gets_emits_one_event() {
     // observes the entry and emits.
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            default_ttl: Some(Duration::from_millis(40)),
+            default_ttl: Some(Duration::from_secs(5)),
             ..Default::default()
         })
         .build();
     p.insert(E { id: 1 }).await.unwrap();
     let mut rx = p.events();
 
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    tokio::time::advance(Duration::from_secs(6)).await;
 
     // Fan out 16 concurrent `get`s. Each runs sync; tokio just
     // schedules them on the runtime.
@@ -211,7 +224,7 @@ async fn lazy_expiry_under_concurrent_gets_emits_one_event() {
         if matches!(
             ev,
             PunnuEvent::Invalidate {
-                reason: InvalidationReason::TtlExpired,
+                reason: EventReason::TtlExpired,
                 ..
             }
         ) {

--- a/sassi/tests/punnu_ttl_lazy.rs
+++ b/sassi/tests/punnu_ttl_lazy.rs
@@ -70,7 +70,7 @@ async fn ttl_expires_lazily_on_get() {
     match rx.try_recv().expect("expected TtlExpired event") {
         PunnuEvent::Invalidate {
             id: 1,
-            reason: EventReason::TtlExpired(_),
+            reason: EventReason::TtlExpired { .. },
         } => {}
         other => panic!("expected TtlExpired for id=1, got {other:?}"),
     }
@@ -157,7 +157,7 @@ async fn lazy_expiry_event_fires_at_most_once_for_a_given_entry() {
         if matches!(
             ev,
             PunnuEvent::Invalidate {
-                reason: EventReason::TtlExpired(_),
+                reason: EventReason::TtlExpired { .. },
                 ..
             }
         ) {
@@ -224,7 +224,7 @@ async fn lazy_expiry_under_concurrent_gets_emits_one_event() {
         if matches!(
             ev,
             PunnuEvent::Invalidate {
-                reason: EventReason::TtlExpired(_),
+                reason: EventReason::TtlExpired { .. },
                 ..
             }
         ) {

--- a/sassi/tests/punnu_ttl_lazy.rs
+++ b/sassi/tests/punnu_ttl_lazy.rs
@@ -70,7 +70,7 @@ async fn ttl_expires_lazily_on_get() {
     match rx.try_recv().expect("expected TtlExpired event") {
         PunnuEvent::Invalidate {
             id: 1,
-            reason: EventReason::TtlExpired,
+            reason: EventReason::TtlExpired(_),
         } => {}
         other => panic!("expected TtlExpired for id=1, got {other:?}"),
     }
@@ -157,7 +157,7 @@ async fn lazy_expiry_event_fires_at_most_once_for_a_given_entry() {
         if matches!(
             ev,
             PunnuEvent::Invalidate {
-                reason: EventReason::TtlExpired,
+                reason: EventReason::TtlExpired(_),
                 ..
             }
         ) {
@@ -224,7 +224,7 @@ async fn lazy_expiry_under_concurrent_gets_emits_one_event() {
         if matches!(
             ev,
             PunnuEvent::Invalidate {
-                reason: EventReason::TtlExpired,
+                reason: EventReason::TtlExpired(_),
                 ..
             }
         ) {

--- a/sassi/tests/punnu_ttl_lazy.rs
+++ b/sassi/tests/punnu_ttl_lazy.rs
@@ -1,0 +1,225 @@
+//! Task 6 — TTL lazy-expiry path.
+//!
+//! Spec §6.2.5: when an entry's `expires_at` deadline has passed,
+//! `Punnu::get` returns `None`, removes the entry from L1, and emits
+//! a `PunnuEvent::Invalidate { reason: TtlExpired }`. This file
+//! exercises that contract — the background sweep variant lives in
+//! `punnu_ttl_sweep.rs`.
+
+use sassi::{Cacheable, Field, InvalidationReason, Punnu, PunnuConfig, PunnuEvent};
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+}
+
+#[tokio::test]
+async fn ttl_expires_lazily_on_get() {
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_millis(50)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+    assert!(
+        p.get(&1).is_some(),
+        "entry visible immediately after insert"
+    );
+
+    // Subscribe BEFORE the expiry triggers so we can observe the
+    // TtlExpired event without racing.
+    let mut rx = p.events();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    assert!(
+        p.get(&1).is_none(),
+        "expired entry should be None after TTL elapses"
+    );
+
+    // The lazy-expiry path emits TtlExpired exactly once for the
+    // observed entry.
+    match rx.try_recv().expect("expected TtlExpired event") {
+        PunnuEvent::Invalidate {
+            id: 1,
+            reason: InvalidationReason::TtlExpired,
+        } => {}
+        other => panic!("expected TtlExpired for id=1, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn no_default_ttl_means_no_expiry() {
+    // With `default_ttl = None`, entries should never expire on time.
+    let p = Punnu::<E>::builder().build();
+    p.insert(E { id: 1 }).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(p.get(&1).is_some(), "no TTL configured — entry must remain");
+}
+
+#[tokio::test]
+async fn insert_with_ttl_overrides_config_default() {
+    // Per-entry override: even though the pool default is 60s,
+    // the explicit insert_with_ttl wins for this entry.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_secs(60)),
+            ..Default::default()
+        })
+        .build();
+    p.insert_with_ttl(E { id: 1 }, Duration::from_millis(50))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    assert!(
+        p.get(&1).is_none(),
+        "entry-level TTL must override pool default"
+    );
+}
+
+#[tokio::test]
+async fn insert_with_ttl_overrides_when_pool_default_is_none() {
+    // Per-entry TTL works even when the pool has no default.
+    let p = Punnu::<E>::builder().build();
+    p.insert_with_ttl(E { id: 1 }, Duration::from_millis(50))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    assert!(p.get(&1).is_none());
+}
+
+#[tokio::test]
+async fn lazy_expiry_decrements_len() {
+    // After lazy expiry on get, the entry must be physically gone.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_millis(40)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+    assert_eq!(p.len(), 1);
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    let _ = p.get(&1); // triggers lazy expiry
+    assert_eq!(p.len(), 0, "lazy expiry must remove the entry from L1");
+}
+
+#[tokio::test]
+async fn lazy_expiry_event_fires_at_most_once_for_a_given_entry() {
+    // Two `get`s after expiry should not produce two TtlExpired
+    // events — the first `get` removes the entry; the second `get`
+    // observes a miss with no event.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_millis(40)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+    let mut rx = p.events();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // First get: triggers lazy expiry, emits TtlExpired.
+    assert!(p.get(&1).is_none());
+    // Second get: cache miss, no event.
+    assert!(p.get(&1).is_none());
+
+    let mut ttl_events_observed = 0;
+    while let Ok(ev) = rx.try_recv() {
+        if matches!(
+            ev,
+            PunnuEvent::Invalidate {
+                reason: InvalidationReason::TtlExpired,
+                ..
+            }
+        ) {
+            ttl_events_observed += 1;
+        }
+    }
+    assert_eq!(
+        ttl_events_observed, 1,
+        "TtlExpired must fire exactly once per expired entry, even with multiple gets"
+    );
+}
+
+#[tokio::test]
+async fn unexpired_get_does_not_emit_ttl_event() {
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_millis(500)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+    let mut rx = p.events();
+
+    // Get before TTL elapses — no event should fire.
+    assert!(p.get(&1).is_some());
+    assert!(matches!(
+        rx.try_recv(),
+        Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+    ));
+}
+
+#[tokio::test]
+async fn lazy_expiry_under_concurrent_gets_emits_one_event() {
+    // Race condition probe: many concurrent `get` calls for the same
+    // expired entry must collectively produce at most one
+    // `TtlExpired` event. The expiry decision + pop happen under the
+    // same write lock, so only the first `get` to acquire the lock
+    // observes the entry and emits.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_millis(40)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+    let mut rx = p.events();
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Fan out 16 concurrent `get`s. Each runs sync; tokio just
+    // schedules them on the runtime.
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let p = p.clone();
+        handles.push(tokio::spawn(async move { p.get(&1) }));
+    }
+    for h in handles {
+        let v = h.await.unwrap();
+        assert!(v.is_none(), "all concurrent gets must observe miss");
+    }
+
+    let mut ttl_events_observed = 0;
+    while let Ok(ev) = rx.try_recv() {
+        if matches!(
+            ev,
+            PunnuEvent::Invalidate {
+                reason: InvalidationReason::TtlExpired,
+                ..
+            }
+        ) {
+            ttl_events_observed += 1;
+        }
+    }
+    assert_eq!(
+        ttl_events_observed, 1,
+        "at most one TtlExpired event must fire across concurrent gets for an expired entry"
+    );
+}

--- a/sassi/tests/punnu_ttl_sweep.rs
+++ b/sassi/tests/punnu_ttl_sweep.rs
@@ -1,0 +1,185 @@
+//! Task 6 — TTL background-sweep path.
+//!
+//! Spec §6.2.5: when [`PunnuConfig::ttl_sweep_interval`] is `Some`,
+//! a background task scans the L1 every interval tick, removes
+//! anything whose `expires_at` has elapsed, and emits
+//! `PunnuEvent::Invalidate { reason: TtlExpired }` for each. This
+//! file exercises that path; the lazy variant lives in
+//! `punnu_ttl_lazy.rs`.
+//!
+//! The sweep is gated behind the `runtime-tokio` feature (it
+//! depends on `tokio::spawn`); these tests use the default feature
+//! set, which includes `runtime-tokio`.
+
+use sassi::{Cacheable, Field, InvalidationReason, Punnu, PunnuConfig, PunnuEvent};
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+}
+
+#[tokio::test]
+async fn sweep_removes_expired_without_get() {
+    // Without sweep, an expired entry stays in L1 storage until a
+    // `get` triggers the lazy path. With sweep configured, it's
+    // gone from `len` after at most one sweep interval after expiry.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_millis(50)),
+            ttl_sweep_interval: Some(Duration::from_millis(20)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+    assert_eq!(p.len(), 1);
+
+    // Wait long enough for: TTL elapsed (50ms) + at least one sweep
+    // tick after expiry (20ms) + the initial tick the sweep skips
+    // (20ms) + slack. 200ms is generous and keeps the test stable
+    // on slow CI.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert_eq!(
+        p.len(),
+        0,
+        "background sweep should have removed the expired entry"
+    );
+}
+
+#[tokio::test]
+async fn sweep_emits_ttl_expired_event() {
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_millis(50)),
+            ttl_sweep_interval: Some(Duration::from_millis(20)),
+            ..Default::default()
+        })
+        .build();
+    let mut rx = p.events();
+    p.insert(E { id: 7 }).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Drain everything; we should observe an Insert + a TtlExpired
+    // event for id 7.
+    let mut saw_ttl = false;
+    while let Ok(ev) = rx.try_recv() {
+        if matches!(
+            ev,
+            PunnuEvent::Invalidate {
+                id: 7,
+                reason: InvalidationReason::TtlExpired,
+            }
+        ) {
+            saw_ttl = true;
+        }
+    }
+    assert!(saw_ttl, "background sweep must emit TtlExpired");
+}
+
+#[tokio::test]
+async fn sweep_does_not_remove_unexpired_entries() {
+    // An entry whose TTL hasn't elapsed must survive the sweep.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            // Long TTL on the entry, short sweep interval.
+            default_ttl: Some(Duration::from_secs(5)),
+            ttl_sweep_interval: Some(Duration::from_millis(20)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+
+    // Several sweep ticks pass without the TTL elapsing.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    assert_eq!(p.len(), 1, "unexpired entry must survive the sweep");
+    assert!(p.get(&1).is_some());
+}
+
+#[tokio::test]
+async fn sweep_handles_mixed_expired_and_fresh() {
+    // Insert two entries with different TTLs. The shorter expires;
+    // the longer survives.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            ttl_sweep_interval: Some(Duration::from_millis(20)),
+            ..Default::default()
+        })
+        .build();
+    p.insert_with_ttl(E { id: 1 }, Duration::from_millis(40))
+        .await
+        .unwrap();
+    p.insert_with_ttl(E { id: 2 }, Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(180)).await;
+
+    assert!(
+        p.get(&1).is_none(),
+        "id 1 (40ms TTL) should have been swept"
+    );
+    assert!(p.get(&2).is_some(), "id 2 (5s TTL) should still be present");
+}
+
+#[tokio::test]
+async fn sweep_terminates_when_punnu_dropped() {
+    // Owner-loss cancellation: when every Punnu<T> clone is dropped,
+    // the sweep's Weak::upgrade returns None on the next tick and
+    // the task exits. This is structural rather than observable —
+    // we verify that we can drop the pool without hangs and that
+    // dropping doesn't panic. The strong indicator is that the
+    // test process exits cleanly (no orphan tasks holding refs).
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            ttl_sweep_interval: Some(Duration::from_millis(10)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+    drop(p);
+    // Give the sweep one or two ticks to observe the drop and exit.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    // No assertion — the test is the absence of a hang or panic.
+}
+
+#[tokio::test]
+async fn sweep_interval_off_means_no_background_removal() {
+    // Default config has `ttl_sweep_interval = None`. An expired
+    // entry stays in L1 (occupying capacity) until a `get` triggers
+    // the lazy path. This matches the spec — sweep is opt-in.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_millis(40)),
+            // ttl_sweep_interval explicitly None.
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    assert_eq!(
+        p.len(),
+        1,
+        "without ttl_sweep_interval, expired entries stay until next get"
+    );
+
+    // The lazy path then removes it.
+    assert!(p.get(&1).is_none());
+    assert_eq!(p.len(), 0);
+}

--- a/sassi/tests/punnu_ttl_sweep.rs
+++ b/sassi/tests/punnu_ttl_sweep.rs
@@ -154,7 +154,7 @@ async fn sweep_emits_ttl_expired_event() {
             ev,
             PunnuEvent::Invalidate {
                 id: 7,
-                reason: EventReason::TtlExpired(_),
+                reason: EventReason::TtlExpired { .. },
             }
         ) {
             saw_ttl = true;

--- a/sassi/tests/punnu_ttl_sweep.rs
+++ b/sassi/tests/punnu_ttl_sweep.rs
@@ -71,9 +71,18 @@ impl Cacheable for E {
 /// its interval, awaits the immediate first tick (the sweep skips
 /// it), and parks on the second tick. Subsequent `advance` calls
 /// will then fire the registered timer.
+///
+/// **Heuristic, not a guarantee.** Tokio does not formally guarantee
+/// scheduling order after [`tokio::task::yield_now`]; two yields
+/// cover the common case (current_thread runtime + paused clock +
+/// spawn-then-tick sequence) but a future scheduler change could
+/// make this flake. A `tokio::sync::Notify`-based handshake from
+/// the sweep task to the test would be deterministic; tracked for
+/// the v0.2 testing-helper refactor in
+/// <https://github.com/TarunvirBains/sassi/issues/4>. For v0.1.0,
+/// these tests have been stable across CI runs and the heuristic
+/// is acceptable.
 async fn prime_sweep() {
-    // Two yields cover both the spawn point and the immediate first
-    // tick the sweep awaits-and-discards. Cheap, deterministic.
     tokio::task::yield_now().await;
     tokio::task::yield_now().await;
 }
@@ -145,7 +154,7 @@ async fn sweep_emits_ttl_expired_event() {
             ev,
             PunnuEvent::Invalidate {
                 id: 7,
-                reason: EventReason::TtlExpired,
+                reason: EventReason::TtlExpired(_),
             }
         ) {
             saw_ttl = true;
@@ -220,6 +229,48 @@ async fn sweep_terminates_when_punnu_dropped() {
     tokio::time::advance(Duration::from_secs(5)).await;
     drive_sweep_ticks(4).await;
     // No assertion — the test is the absence of a hang or panic.
+}
+
+#[tokio::test(start_paused = true)]
+async fn sweep_removes_on_configured_tick_boundary() {
+    // Cadence test — confirms removal happens on a sweep tick, not
+    // before. With ttl_sweep_interval = 1s and default_ttl = 2s:
+    // - At t=0: insert.
+    // - Advance to t=1.5s (past first tick at t=1s, before TTL at t=2s):
+    //   sweep ticks but entry is still fresh — nothing removed.
+    // - Advance to t=2.5s (past TTL): entry is now expired but the
+    //   sweep tick at t=2s already passed. The sweep at t=3s observes
+    //   expiry and removes. Until then, len() == 1 (lazy path
+    //   uninvoked since we don't call get).
+    // - Drive ticks; verify removal.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_secs(2)),
+            ttl_sweep_interval: Some(Duration::from_secs(1)),
+            ..Default::default()
+        })
+        .build();
+    p.insert(E { id: 1 }).await.unwrap();
+
+    prime_sweep().await;
+
+    // Just past the first sweep tick — entry not yet expired.
+    tokio::time::advance(Duration::from_millis(1500)).await;
+    drive_sweep_ticks(2).await;
+    assert_eq!(
+        p.len(),
+        1,
+        "sweep at t=1s ran but entry (TTL 2s) is still fresh"
+    );
+
+    // Cross the TTL deadline AND the next sweep tick.
+    tokio::time::advance(Duration::from_millis(1500)).await;
+    drive_sweep_ticks(2).await;
+    assert_eq!(
+        p.len(),
+        0,
+        "sweep at t=3s should have removed expired entry"
+    );
 }
 
 #[tokio::test(start_paused = true)]

--- a/sassi/tests/punnu_ttl_sweep.rs
+++ b/sassi/tests/punnu_ttl_sweep.rs
@@ -8,10 +8,27 @@
 //! `punnu_ttl_lazy.rs`.
 //!
 //! The sweep is gated behind the `runtime-tokio` feature (it
-//! depends on `tokio::spawn`); these tests use the default feature
-//! set, which includes `runtime-tokio`.
+//! depends on `tokio::spawn`); this whole test file is gated the
+//! same way so the no-default-features build (`cargo test
+//! --no-default-features`) skips it cleanly. With the feature off,
+//! `Punnu::insert` succeeds but the sweep task never spawns, so the
+//! "sweep should have removed expired entry" assertions would fail
+//! silently — the gate makes that contract explicit.
+//!
+//! All tests run under `#[tokio::test(start_paused = true)]` and use
+//! `tokio::time::advance(...)` to drive virtual time forward
+//! deterministically. Sassi's TTL bookkeeping reads
+//! `tokio::time::Instant::now()`, which honours the paused clock, so
+//! advancement is observable to the cache. Background sweep ticks
+//! also fire under the paused clock — `tokio::time::interval` is
+//! governed by the same virtual clock — so a `tokio::task::yield_now`
+//! after `advance` is sufficient to let the sweep loop process its
+//! pending tick(s). No real `sleep` calls; the tests are impervious
+//! to CI scheduling jitter.
 
-use sassi::{Cacheable, Field, InvalidationReason, Punnu, PunnuConfig, PunnuEvent};
+#![cfg(feature = "runtime-tokio")]
+
+use sassi::{Cacheable, EventReason, Field, Punnu, PunnuConfig, PunnuEvent};
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -31,28 +48,71 @@ impl Cacheable for E {
     fn id(&self) -> i64 {
         self.id
     }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+        }
+    }
 }
 
-#[tokio::test]
+/// Anchor the background sweep task's interval timer at the current
+/// virtual time.
+///
+/// `tokio::spawn(...)` queues the sweep's future but doesn't poll it
+/// until the runtime yields; on a `current_thread` runtime under
+/// `#[tokio::test(start_paused = true)]`, that means the sweep's
+/// `tokio::time::interval` is constructed only after the test code
+/// yields. If we `advance` before the sweep has been polled, the
+/// interval anchors at the *advanced* time and the sweep wakes one
+/// interval *after* the advance — the test then sees no removal.
+///
+/// Calling `prime_sweep` after `Punnu::builder().build()` and any
+/// inserts forces the sweep to be polled at least once: it creates
+/// its interval, awaits the immediate first tick (the sweep skips
+/// it), and parks on the second tick. Subsequent `advance` calls
+/// will then fire the registered timer.
+async fn prime_sweep() {
+    // Two yields cover both the spawn point and the immediate first
+    // tick the sweep awaits-and-discards. Cheap, deterministic.
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+}
+
+/// Yield enough times for the background sweep loop to process its
+/// pending wake-ups after a `tokio::time::advance`. The sweep task's
+/// `tick.tick().await` is a wakeup point on the paused clock; one
+/// yield per tick we want to process is sufficient because the sweep
+/// does no awaits between ticks (it acquires the L1 lock
+/// synchronously, drains, releases).
+async fn drive_sweep_ticks(n: usize) {
+    for _ in 0..n {
+        tokio::task::yield_now().await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
 async fn sweep_removes_expired_without_get() {
     // Without sweep, an expired entry stays in L1 storage until a
     // `get` triggers the lazy path. With sweep configured, it's
     // gone from `len` after at most one sweep interval after expiry.
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            default_ttl: Some(Duration::from_millis(50)),
-            ttl_sweep_interval: Some(Duration::from_millis(20)),
+            default_ttl: Some(Duration::from_secs(5)),
+            ttl_sweep_interval: Some(Duration::from_secs(1)),
             ..Default::default()
         })
         .build();
     p.insert(E { id: 1 }).await.unwrap();
     assert_eq!(p.len(), 1);
 
-    // Wait long enough for: TTL elapsed (50ms) + at least one sweep
-    // tick after expiry (20ms) + the initial tick the sweep skips
-    // (20ms) + slack. 200ms is generous and keeps the test stable
-    // on slow CI.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    // Pin the sweep's interval timer at virtual t=0 before advancing.
+    prime_sweep().await;
+
+    // Advance past TTL and several sweep ticks. The sweep skips the
+    // first immediate tick (see `spawn_sweep`), so we need a couple
+    // of ticks past the expiry to be sure the sweep observed it.
+    tokio::time::advance(Duration::from_secs(10)).await;
+    drive_sweep_ticks(4).await;
 
     assert_eq!(
         p.len(),
@@ -61,19 +121,21 @@ async fn sweep_removes_expired_without_get() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sweep_emits_ttl_expired_event() {
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            default_ttl: Some(Duration::from_millis(50)),
-            ttl_sweep_interval: Some(Duration::from_millis(20)),
+            default_ttl: Some(Duration::from_secs(5)),
+            ttl_sweep_interval: Some(Duration::from_secs(1)),
             ..Default::default()
         })
         .build();
     let mut rx = p.events();
     p.insert(E { id: 7 }).await.unwrap();
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    prime_sweep().await;
+    tokio::time::advance(Duration::from_secs(10)).await;
+    drive_sweep_ticks(4).await;
 
     // Drain everything; we should observe an Insert + a TtlExpired
     // event for id 7.
@@ -83,7 +145,7 @@ async fn sweep_emits_ttl_expired_event() {
             ev,
             PunnuEvent::Invalidate {
                 id: 7,
-                reason: InvalidationReason::TtlExpired,
+                reason: EventReason::TtlExpired,
             }
         ) {
             saw_ttl = true;
@@ -92,52 +154,53 @@ async fn sweep_emits_ttl_expired_event() {
     assert!(saw_ttl, "background sweep must emit TtlExpired");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sweep_does_not_remove_unexpired_entries() {
     // An entry whose TTL hasn't elapsed must survive the sweep.
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
             // Long TTL on the entry, short sweep interval.
-            default_ttl: Some(Duration::from_secs(5)),
-            ttl_sweep_interval: Some(Duration::from_millis(20)),
+            default_ttl: Some(Duration::from_secs(60 * 60)),
+            ttl_sweep_interval: Some(Duration::from_secs(1)),
             ..Default::default()
         })
         .build();
     p.insert(E { id: 1 }).await.unwrap();
 
     // Several sweep ticks pass without the TTL elapsing.
-    tokio::time::sleep(Duration::from_millis(120)).await;
+    prime_sweep().await;
+    tokio::time::advance(Duration::from_secs(5)).await;
+    drive_sweep_ticks(6).await;
     assert_eq!(p.len(), 1, "unexpired entry must survive the sweep");
     assert!(p.get(&1).is_some());
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sweep_handles_mixed_expired_and_fresh() {
     // Insert two entries with different TTLs. The shorter expires;
     // the longer survives.
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            ttl_sweep_interval: Some(Duration::from_millis(20)),
+            ttl_sweep_interval: Some(Duration::from_secs(1)),
             ..Default::default()
         })
         .build();
-    p.insert_with_ttl(E { id: 1 }, Duration::from_millis(40))
+    p.insert_with_ttl(E { id: 1 }, Duration::from_secs(5))
         .await
         .unwrap();
-    p.insert_with_ttl(E { id: 2 }, Duration::from_secs(5))
+    p.insert_with_ttl(E { id: 2 }, Duration::from_secs(60 * 60))
         .await
         .unwrap();
 
-    tokio::time::sleep(Duration::from_millis(180)).await;
+    prime_sweep().await;
+    tokio::time::advance(Duration::from_secs(10)).await;
+    drive_sweep_ticks(4).await;
 
-    assert!(
-        p.get(&1).is_none(),
-        "id 1 (40ms TTL) should have been swept"
-    );
-    assert!(p.get(&2).is_some(), "id 2 (5s TTL) should still be present");
+    assert!(p.get(&1).is_none(), "id 1 (5s TTL) should have been swept");
+    assert!(p.get(&2).is_some(), "id 2 (1h TTL) should still be present");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sweep_terminates_when_punnu_dropped() {
     // Owner-loss cancellation: when every Punnu<T> clone is dropped,
     // the sweep's Weak::upgrade returns None on the next tick and
@@ -147,32 +210,34 @@ async fn sweep_terminates_when_punnu_dropped() {
     // test process exits cleanly (no orphan tasks holding refs).
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            ttl_sweep_interval: Some(Duration::from_millis(10)),
+            ttl_sweep_interval: Some(Duration::from_secs(1)),
             ..Default::default()
         })
         .build();
     p.insert(E { id: 1 }).await.unwrap();
     drop(p);
     // Give the sweep one or two ticks to observe the drop and exit.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    tokio::time::advance(Duration::from_secs(5)).await;
+    drive_sweep_ticks(4).await;
     // No assertion — the test is the absence of a hang or panic.
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn sweep_interval_off_means_no_background_removal() {
     // Default config has `ttl_sweep_interval = None`. An expired
     // entry stays in L1 (occupying capacity) until a `get` triggers
     // the lazy path. This matches the spec — sweep is opt-in.
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
-            default_ttl: Some(Duration::from_millis(40)),
+            default_ttl: Some(Duration::from_secs(5)),
             // ttl_sweep_interval explicitly None.
             ..Default::default()
         })
         .build();
     p.insert(E { id: 1 }).await.unwrap();
 
-    tokio::time::sleep(Duration::from_millis(120)).await;
+    tokio::time::advance(Duration::from_secs(10)).await;
+    drive_sweep_ticks(4).await;
     assert_eq!(
         p.len(),
         1,


### PR DESCRIPTION
## Cluster A — Punnu core

Implements Tasks 4-6 of the sassi v0.1.0-alpha plan.

### What lands

- **Task 4 (`Punnu<T>` core):** typed in-memory pool with `insert` / `get` / `invalidate` / `len` / `is_empty` / `events` / `config`. Backed by `std::sync::RwLock<LruCache<T::Id, Entry<T>>>` behind `Arc<PunnuInner<T>>`, so `Punnu<T>: Clone` observes the same identity map across handlers and (later) scopes. `OnConflict` policy fully wired: `LastWriteWins` (default) emits `Insert`, `Reject` returns `InsertError::Conflict`, `Update` emits `PunnuEvent::Update { old, new }`. LRU eviction emits `Invalidate { reason: LruEvict }` ordered before the new entry's `Insert` event. `PunnuConfig` ships at full v0.1 shape (lru/event/conflict/backend/TTL/namespace/metrics fields) so error composition stays stable from v0.1.0-alpha.0 onward. `BackendError` + `InsertError` pinned in `error.rs`. `TenantKey` newtype + `From<String>` / `From<&str>` / `Display` impls (cross-tenant guards land in a later task).

- **Task 5 (events stream):** nine integration tests in `sassi/tests/punnu_events.rs` covering insert / invalidate / replace-under-LastWriteWins / replace-under-Update / LRU-evict event ordering / lossy-under-load (`RecvError::Lagged` does not crash the producer) / no-active-subscribers / unknown-id-no-event idempotency. No new code — exercises the broadcast wiring that landed in Task 4.

- **Task 6 (TTL — lazy + sweep):** lazy expiry on `Punnu::get` (peek-then-decide under the L1 write lock; race-safe so at most one `TtlExpired` event fires per expired entry even with 16 concurrent gets) plus opt-in background sweep gated behind the `runtime-tokio` feature. Sweep cancellation is structural via `Weak<PunnuInner<T>>` — no `JoinHandle`, no `Notify`, the strong-count drop *is* the shutdown signal. `insert_with_ttl(value, ttl)` wired as the per-entry override for `PunnuConfig::default_ttl`.

### Verification

```
cargo fmt --all -- --check                                      ✓
cargo clippy --workspace --all-targets --all-features -- -D warnings  ✓
cargo clippy --workspace --no-default-features --features serde -- -D warnings  ✓
cargo test --workspace                                          ✓ (60 tests pass)
```

### Test count

- Pre-existing: 4 (predicate_basic) + 16 (predicate algebra unit) + 7 (cacheable_derive) + 1 (trybuild compile-fail) + doctests = 28
- Cluster A new: 9 (`punnu_identity_map`) + 9 (`punnu_events`) + 8 (`punnu_ttl_lazy`) + 6 (`punnu_ttl_sweep`) = 32
- **Total: 60 tests pass across all feature configurations**

### Notable design choices (deviations from plan, all anchored)

- **Storage shape decision:** landed `Entry<T>` with `expires_at: Option<Instant>` in Task 4 rather than refactoring storage in Task 6. Cleaner intermediate state per the dispatch directive — Task 6 only adds *behavior* (lazy check + sweep + `insert_with_ttl`), no storage churn.
- **`PunnuConfig` is not `#[non_exhaustive]`:** the canonical construction pattern is struct-update (`PunnuConfig { lru_size: …, ..Default::default() }`), which `#[non_exhaustive]` blocks from outside the crate. Forward-compat is documented in the rustdoc — adopters who use struct-update with `..Default::default()` upgrade across minor versions without source changes.
- **`tokio` is unconditional, `runtime-tokio` gates only the sweep:** the broadcast channel that backs the event stream is `tokio::sync::broadcast`, which works on every supported target (including WASM) and doesn't require a runtime. `runtime-tokio` now governs only the spawn-driven sweep behaviour. `tokio = { workspace = true, optional = true }` → `tokio = { workspace = true }`. Workspace tokio features bumped to `["sync", "rt", "time", "macros"]`.
- **Default features include `runtime-tokio`:** matches the typical native consumer; the test suite uses `#[tokio::test]` and depends on the sweep tests building. WASM consumers set `default-features = false, features = ["serde", "runtime-wasm"]` (the `runtime-wasm` executor lands in a later task).
- **`thiserror` added to workspace dependencies** for `InsertError` / `BackendError` derive (de facto Rust convention; no extra weight).

### Plan

Tasks 4-6 of `docs/superpowers/plans/2026-05-01-sassi-v0.1.0.md`.

### Test plan

- [ ] Reviewer reads through `sassi/src/punnu/{pool,ttl,events,config,tenant}.rs` for shape clarity.
- [ ] Reviewer scans the 32 new tests in `sassi/tests/punnu_*.rs` for coverage gaps (esp. concurrent-gets race in `punnu_ttl_lazy.rs`).
- [ ] CI runs `cargo fmt --check`, `cargo clippy --all-features -D warnings`, `cargo test --workspace` and lands green.
- [ ] CI also exercises the `--no-default-features --features serde` path (WASM-shaped build without the sweep) — verified locally; CI matrix may need a new line.