### PR TITLE
Cluster B — Runtime decoupling + single-flight fetch + config polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           key: ${{ runner.os }}-cargo-redis-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-redis-
 
-      # sassi-cache-redis lands in Task 13; until then this job is a
+      # sassi-cache-redis is a future companion crate; until it lands this job is a
       # no-op. Detect via `cargo metadata` rather than gating on a
       # path filter so re-adding the crate later requires no workflow
       # edit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,36 @@ jobs:
       - name: Test (no-default-features minimal)
         run: cargo test -p sassi --no-default-features
 
+  wasm-target:
+    name: WASM target build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust + wasm32 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry/git/target (wasm)
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-wasm-
+
+      # Builds sassi against `wasm32-unknown-unknown` with the
+      # `runtime-wasm` feature so any regression in the cfg-gated
+      # executor / time / TTL paths fails CI. Cluster B, Task 10 wired
+      # the feature; this job pins the contract. Per-test wasm
+      # execution (wasm-bindgen-test) is deferred to Task 18.
+      - name: Build sassi for wasm32
+        run: cargo build -p sassi --target wasm32-unknown-unknown --no-default-features --features "serde,runtime-wasm"
+
   msrv:
     name: MSRV (Rust 1.95)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,8 @@ jobs:
 
       # Builds sassi against `wasm32-unknown-unknown` with the
       # `runtime-wasm` feature so any regression in the cfg-gated
-      # executor / time / TTL paths fails CI. Cluster B, Task 10 wired
-      # the feature; this job pins the contract. Per-test wasm
-      # execution (wasm-bindgen-test) is deferred to Task 18.
+      # executor / time / TTL paths fails CI. Per-test wasm execution
+      # (wasm-bindgen-test) is deferred to a future CI matrix expansion.
       - name: Build sassi for wasm32
         run: cargo build -p sassi --target wasm32-unknown-unknown --no-default-features --features "serde,runtime-wasm"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +213,18 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -279,12 +309,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "sassi"
 version = "0.1.0-alpha.0"
 dependencies = [
  "async-trait",
  "dashmap",
  "futures",
+ "gloo-timers",
  "lru",
  "sassi-macros",
  "serde",
@@ -292,6 +329,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -543,6 +582,71 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,20 @@ tracing = "0.1"
 # Async-trait — until trait async stabilizes for object-safe traits
 async-trait = "0.1"
 
+# Cross-target monotonic clock. On native, `web_time::Instant` is a
+# re-export of `std::time::Instant`; on `wasm32-unknown-unknown`, it
+# wraps `Performance.now()`. Used by sassi only on wasm — native
+# builds keep `tokio::time::Instant` so tests retain
+# `tokio::time::pause()` / `advance(...)` determinism. Workspace dep
+# so the wasm-side feature pulls a single, vetted version.
+web-time = "1"
+
+# WASM-only spawn + sleep primitives. Pulled in by the `runtime-wasm`
+# feature on the sassi crate; the workspace declares the version so
+# the choice is auditable in one place.
+wasm-bindgen-futures = "0.4"
+gloo-timers = { version = "0.4", features = ["futures"] }
+
 # Macro substrate
 proc-macro2 = "1"
 quote = "1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sassi
 
-**Sassi** is a typed in-memory pool with composable predicate algebra and cross-runtime trait queries — designed for cross-runtime use (backend or Dioxus frontend) without coupling to a particular ORM, web framework, or storage layer. WASM target support tracking in [issue #3](https://github.com/TarunvirBains/sassi/issues/3) (lands via Cluster B Task 10's `PunnuExecutor` abstraction); see Status below.
+**Sassi** is a typed in-memory pool with composable predicate algebra and cross-runtime trait queries — designed for cross-runtime use (backend or Dioxus frontend) without coupling to a particular ORM, web framework, or storage layer. The `runtime-wasm` feature compiles sassi clean against `wasm32-unknown-unknown`; per-test wasm execution and full-CI matrix expansion track [issue #3](https://github.com/TarunvirBains/sassi/issues/3) (see Status below).
 
 ## What it gives you
 
@@ -14,7 +14,7 @@
 
 **Pre-v0.1.0 alpha.** This repository is currently a skeleton; implementation lands per the design spec under `docs/superpowers/specs/` (local-only). v0.1.0 ships in lockstep with the [djogi](https://github.com/TarunvirBains/djogi) framework's v0.1.0 cut.
 
-- **WASM target** — deferred per [issue #3](https://github.com/TarunvirBains/sassi/issues/3); supported in v0.1.0 via Cluster B Task 10's `PunnuExecutor` abstraction (with Task 18 closing the CI matrix). The `runtime-wasm` feature flag is declared today as a forward-compatibility hook; no code is gated behind it yet.
+- **WASM target** — sassi compiles clean for `wasm32-unknown-unknown` under the `runtime-wasm` feature; the `wasm-target` CI job pins the contract. Per-test wasm execution (`wasm-bindgen-test` runner) and the full multi-target CI matrix track [issue #3](https://github.com/TarunvirBains/sassi/issues/3).
 
 ## Workspace layout
 

--- a/sassi/Cargo.toml
+++ b/sassi/Cargo.toml
@@ -17,18 +17,18 @@ rust-version.workspace = true
 # `runtime-tokio` enables the optional background TTL sweep task and is
 # the typical setup for native consumers; tests rely on it via
 # `#[tokio::test]`. `runtime-wasm` is the WASM-target counterpart and
-# selects the gloo-timers-based executor.
+# selects the gloo-timers-based executor (Cluster B, Task 10).
 #
-# `runtime-wasm` is reserved for Cluster B, Task 10 (`PunnuExecutor`
-# abstraction) — the flag is declared today so consumers see the full
-# feature shape, but no code is gated behind it yet. WASM target
-# verification is tracked at
-# https://github.com/TarunvirBains/sassi/issues/3 (also covers Task 18
-# CI matrix work).
+# Selecting `runtime-wasm` only makes sense when building for
+# `wasm32-unknown-unknown` — the deps it pulls in
+# (`wasm-bindgen-futures`, `gloo-timers`) build cleanly on native too,
+# so the feature flag can be enabled on native builds without breakage,
+# but the executor's `spawn` / `sleep` paths only fire under
+# `target_arch = "wasm32"`. Native + `runtime-wasm` is therefore inert.
 default = ["serde", "runtime-tokio"]
 serde = ["dep:serde", "dep:serde_json"]
 runtime-tokio = []
-runtime-wasm = []
+runtime-wasm = ["dep:wasm-bindgen-futures", "dep:gloo-timers"]
 
 [dependencies]
 # `tokio` is unconditional — the broadcast channel that backs Punnu's
@@ -45,6 +45,18 @@ tracing = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 sassi-macros = { path = "../sassi-macros", version = "0.1.0-alpha.0" }
+# `web-time` is a drop-in for `std::time::Instant` that works on
+# `wasm32-unknown-unknown`. Used only on wasm — native builds keep
+# `tokio::time::Instant` so tests retain `tokio::time::pause()` /
+# `advance(...)` determinism. The dep is unconditional because feature
+# resolution is per-package (not per-target); the actual usage is
+# gated `#[cfg(target_arch = "wasm32")]` in the source.
+web-time = { workspace = true }
+# Optional WASM-only spawn / sleep deps. Activated by `runtime-wasm`.
+# Declared as `optional = true` so the default native build doesn't
+# pull them in.
+wasm-bindgen-futures = { workspace = true, optional = true }
+gloo-timers = { workspace = true, optional = true }
 
 [dev-dependencies]
 # `test-util` enables `tokio::time::pause` / `advance` and the

--- a/sassi/Cargo.toml
+++ b/sassi/Cargo.toml
@@ -17,7 +17,7 @@ rust-version.workspace = true
 # `runtime-tokio` enables the optional background TTL sweep task and is
 # the typical setup for native consumers; tests rely on it via
 # `#[tokio::test]`. `runtime-wasm` is the WASM-target counterpart and
-# selects the gloo-timers-based executor (Cluster B, Task 10).
+# selects the gloo-timers-based executor.
 #
 # Selecting `runtime-wasm` only makes sense when building for
 # `wasm32-unknown-unknown` — the deps it pulls in

--- a/sassi/src/cacheable.rs
+++ b/sassi/src/cacheable.rs
@@ -1,5 +1,5 @@
 //! [`Cacheable`] trait + [`Field`] accessor — the identity contract for
-//! entries stored in a `Punnu` (lands in Cluster A).
+//! entries stored in a `Punnu`.
 //!
 //! A `Cacheable` type names its identity column (`Self::Id`), declares
 //! a generated companion struct of [`Field`] accessors (`Self::Fields`),
@@ -21,7 +21,7 @@
 use std::hash::Hash;
 use std::marker::PhantomData;
 
-/// Identity contract for entries stored in a `Punnu` (lands in Cluster A).
+/// Identity contract for entries stored in a `Punnu`.
 ///
 /// Caches the **canonical shape** of `T`. Visage projections (auth-aware
 /// views of a model) get their own independent `Punnu<VisageT>` instance

--- a/sassi/src/error.rs
+++ b/sassi/src/error.rs
@@ -54,6 +54,68 @@ pub enum InsertError {
     BackendFailed(#[from] BackendError),
 }
 
+/// Reasons a [`crate::punnu::Punnu::get_or_fetch`] (or batch variant)
+/// can fail.
+///
+/// Carries either a backend error from the L2 path, a serialization
+/// failure (e.g., when the wire-format envelope rejects a payload), a
+/// fetcher panic surfaced via the single-flight follower path, or an
+/// arbitrary boxed error supplied by the consumer's fetcher closure.
+///
+/// Spec §3.5.1 enumerates the four owner-loss cases the single-flight
+/// path must handle deterministically; `FetcherPanic` is the one that
+/// surfaces here. The other three (originator-drop-with-peers,
+/// all-awaiters-drop, caller-imposed-deadline) don't produce a
+/// `FetchError` — they either leave the fetch alive, drop it cleanly,
+/// or surface as a `tokio::time::error::Elapsed` from the caller's
+/// own `tokio::time::timeout` wrapper.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum FetchError {
+    /// L2 backend operation failed during the fetch path.
+    #[error("backend operation failed during fetch: {0}")]
+    Backend(#[from] BackendError),
+
+    /// Serialization / deserialization of a fetched payload failed.
+    /// Inner string is consumer-supplied (e.g., serde error rendering).
+    #[error("fetch serialization error: {0}")]
+    Serialization(String),
+
+    /// The consumer-supplied fetcher closure panicked. Sassi does not
+    /// `catch_unwind` around the fetcher (that would mask programmer
+    /// bugs); this variant surfaces only via the
+    /// [`futures::future::Shared`] follower-broadcast path described in
+    /// spec §3.5.1: when the fetcher panics, *every* awaiter sees this
+    /// error rather than one peer hanging on a dropped future. The
+    /// `type_name` is `std::any::type_name::<T>()` of the cached type
+    /// — useful as a diagnostic label.
+    #[error("fetcher panicked while resolving {type_name}: {message}")]
+    FetcherPanic {
+        /// `std::any::type_name::<T>()` of the cached type.
+        type_name: &'static str,
+        /// Best-effort panic-payload message (extracted from the
+        /// panic's `Box<dyn Any>`); empty when the payload isn't a
+        /// `String` / `&'static str`.
+        message: String,
+    },
+
+    /// The consumer's fetcher returned a custom error. Boxed so the
+    /// variant size stays small. Use [`FetchError::Custom`] when none
+    /// of the structured variants fit (transport errors specific to
+    /// the consumer's data source, business-logic rejections, etc.).
+    #[error("fetcher error: {0}")]
+    Custom(Box<dyn std::error::Error + Send + Sync>),
+
+    /// L1 insert failed after the fetcher returned a value — surfaces
+    /// when [`crate::punnu::OnConflict::Reject`] is configured and a
+    /// concurrent insert raced ahead, or when an L2 write-through
+    /// fails under [`crate::punnu::BackendFailureMode::Error`]. Lifts
+    /// [`InsertError`] into the fetch error space so
+    /// `Punnu::get_or_fetch` can return a single error type.
+    #[error("L1 insert failed during fetch: {0}")]
+    Insert(#[from] InsertError),
+}
+
 /// Errors from the [`CacheBackend`](crate) trait surface.
 ///
 /// The full backend trait lands in a later task; the variants are

--- a/sassi/src/executor.rs
+++ b/sassi/src/executor.rs
@@ -1,0 +1,204 @@
+//! [`PunnuExecutor`] — internal abstraction over runtime spawn / sleep
+//! / now primitives.
+//!
+//! `pub(crate)` in v0.1; promoted to `pub` in v0.2 alongside an
+//! opt-in `PunnuConfig::executor` field. See spec §3.11 for the full
+//! contract and §3.11.1 for the v0.2 promotion plan.
+//!
+//! # Why an internal trait
+//!
+//! The TTL sweep task and (later) the periodic-refresh helper need
+//! `spawn`, `sleep`, and a monotonic clock. Routing those through a
+//! trait lets sassi compile cleanly on **both** native (tokio) and
+//! `wasm32-unknown-unknown` (gloo-timers + wasm-bindgen-futures)
+//! targets without `cfg`-gating every call site. v0.2 then promotes
+//! the trait to `pub` and adds `PunnuConfig::executor: Option<Arc<dyn
+//! PunnuExecutor>>` so consumers can plug in smol, async-std, or
+//! embedded executors without sassi growing more knobs.
+//!
+//! # Three primitives
+//!
+//! - [`PunnuExecutor::spawn`] — fire-and-forget background task.
+//! - [`PunnuExecutor::sleep`] — async sleep on the runtime's timer.
+//! - [`PunnuExecutor::now`] — read the monotonic clock. The clock
+//!   primitive is part of the executor (rather than a separate
+//!   `Clock` trait) because executor-internal cancellation, sleep
+//!   anchoring, and TTL bookkeeping all read the same clock; keeping
+//!   them on one type avoids a "which clock is which?" confusion when
+//!   v0.2 lets adopters swap executors.
+//!
+//! # Test determinism note
+//!
+//! On native, [`DefaultExecutor::now`] returns
+//! [`tokio::time::Instant::now()`] — the paused-clock-aware variant.
+//! Sassi's TTL tests use `#[tokio::test(start_paused = true)]` and
+//! `tokio::time::advance(...)`; routing reads through the executor
+//! preserves that determinism without exposing a tokio-specific knob
+//! to consumers. The wasm-target counterpart wraps
+//! [`web_time::Instant`] (which uses `Performance.now()` in the
+//! browser); WASM tests are out of scope for v0.1 (tracked at issue
+//! #3).
+
+use crate::time::Instant;
+use std::time::Duration;
+
+// `BoxFut` is the executor's spawn / sleep payload. On native it's
+// the `Send + 'static` `BoxFuture` (sassi assumes a multi-threaded
+// runtime by default). On wasm it's `LocalBoxFuture` — the wasm
+// browser runtime is single-threaded by construction, and several
+// wasm-only primitives (`gloo_timers::future::TimeoutFuture`,
+// `wasm_bindgen_futures::JsFuture`) hold `!Send` JS callbacks.
+// Forcing `Send` would force every wasm sleep through a `Send`
+// shim that doesn't add value on a single-threaded runtime.
+//
+// The split is `cfg(target_arch = "wasm32")` rather than
+// `cfg(feature = "runtime-wasm")` because the bound depends on the
+// target's threading model, not on which feature flag is selected.
+// A native build with `runtime-wasm` enabled (inert per Cargo.toml
+// docs) still uses the `Send` bound.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) type BoxFut<'a> = futures::future::BoxFuture<'a, ()>;
+#[cfg(target_arch = "wasm32")]
+pub(crate) type BoxFut<'a> = futures::future::LocalBoxFuture<'a, ()>;
+
+/// Internal abstraction over runtime primitives — `spawn`, `sleep`,
+/// `now`. Promoted to `pub` in v0.2 with a stable signature; v0.1
+/// users see no change.
+///
+/// The trait is `Send + Sync` on native (the executor handle gets
+/// shared across threads). On wasm it's still `Send + Sync` — the
+/// trait object lives in `Arc<dyn PunnuExecutor>` which propagates
+/// the bounds — but the futures it produces ([`BoxFut`]) are
+/// `!Send` on wasm to allow `gloo_timers` and JS callback closures.
+pub(crate) trait PunnuExecutor: Send + Sync {
+    /// Spawn a fire-and-forget future. The executor decides which
+    /// runtime / thread the future runs on; the caller has no handle
+    /// and no cancellation token. Use [`std::sync::Weak`] inside the
+    /// spawned future when cancellation must follow owner-loss (see
+    /// the TTL sweep in [`crate::punnu::ttl::spawn_sweep`] for the
+    /// pattern).
+    fn spawn(&self, fut: BoxFut<'static>);
+
+    /// Async sleep for `duration`. The returned future yields control
+    /// to the runtime; on a paused tokio clock (`tokio::time::pause()`
+    /// in tests), the sleep advances when the test calls
+    /// `tokio::time::advance(...)`. On wasm, the underlying
+    /// `gloo_timers::future::TimeoutFuture` uses `setTimeout` so the
+    /// sleep advances with browser real time.
+    fn sleep(&self, duration: Duration) -> BoxFut<'static>;
+
+    /// Read the monotonic clock. Returns the executor-appropriate
+    /// [`Instant`] type — on native, `tokio::time::Instant` (paused
+    /// clock honours `tokio::time::pause()`); on wasm,
+    /// `web_time::Instant` (browser `Performance.now()`).
+    ///
+    /// The wrapper [`crate::time::Instant`] type alias keeps the rest
+    /// of sassi free from `cfg(target_arch = "wasm32")` branching at
+    /// every clock-read site.
+    fn now(&self) -> Instant;
+}
+
+/// Default runtime impl. Selected at compile time based on which
+/// `runtime-*` feature is active and which target we're compiling for.
+///
+/// The unit struct carries no state; sassi constructs an
+/// `Arc<DefaultExecutor>` at builder time. v0.2 adopters who want a
+/// custom executor will pass `Arc<MyExecutor>` through
+/// `PunnuConfig::executor`.
+pub(crate) struct DefaultExecutor;
+
+#[cfg(all(feature = "runtime-tokio", not(target_arch = "wasm32")))]
+impl PunnuExecutor for DefaultExecutor {
+    fn spawn(&self, fut: BoxFut<'static>) {
+        // `tokio::spawn` requires an active runtime — sassi assumes
+        // the consumer is on one (typical native setup). With the
+        // sweep task this is the only spawn site; the contract is
+        // documented at the call site too.
+        tokio::spawn(fut);
+    }
+
+    fn sleep(&self, duration: Duration) -> BoxFut<'static> {
+        Box::pin(async move { tokio::time::sleep(duration).await })
+    }
+
+    fn now(&self) -> Instant {
+        // `tokio::time::Instant::now()` is a drop-in for
+        // `std::time::Instant::now()` that honours
+        // `tokio::time::pause()` / `advance(...)` in tests. Production
+        // wall-clock semantics are unchanged.
+        tokio::time::Instant::now()
+    }
+}
+
+#[cfg(all(feature = "runtime-wasm", target_arch = "wasm32"))]
+impl PunnuExecutor for DefaultExecutor {
+    fn spawn(&self, fut: BoxFut<'static>) {
+        wasm_bindgen_futures::spawn_local(fut);
+    }
+
+    fn sleep(&self, duration: Duration) -> BoxFut<'static> {
+        // `gloo_timers::future::TimeoutFuture` takes milliseconds as
+        // a `u32`. Saturate at `u32::MAX` (~49.7 days) — sassi's
+        // legitimate sleep durations fit comfortably under that
+        // bound; the saturation guards against accidental overflow if
+        // a downstream caller passes `Duration::MAX`.
+        let ms = duration.as_millis().min(u32::MAX as u128) as u32;
+        Box::pin(async move { gloo_timers::future::TimeoutFuture::new(ms).await })
+    }
+
+    fn now(&self) -> Instant {
+        // `web_time::Instant::now()` reads the browser's
+        // `Performance.now()` — a high-resolution monotonic clock
+        // suitable for TTL bookkeeping. Native uses
+        // `tokio::time::Instant` instead so test pause/advance keeps
+        // working.
+        web_time::Instant::now()
+    }
+}
+
+// Fallback impl for the awkward case where neither runtime feature
+// is enabled (e.g., `cargo test --no-default-features` without
+// `runtime-tokio`). The fallback panics on spawn / sleep — these
+// methods are only called when the user asked for a background sweep
+// (`PunnuConfig::ttl_sweep_interval = Some(...)`); the panic is a
+// loud failure that points at the missing feature. `now` still works
+// — the same target-aware alias as the runtime impls keeps the
+// lazy-expiry path on `Punnu::get` usable without any executor
+// feature.
+#[cfg(not(any(
+    all(feature = "runtime-tokio", not(target_arch = "wasm32")),
+    all(feature = "runtime-wasm", target_arch = "wasm32"),
+)))]
+impl PunnuExecutor for DefaultExecutor {
+    fn spawn(&self, _fut: BoxFut<'static>) {
+        panic!(
+            "PunnuExecutor::spawn called without a runtime feature; \
+             enable `runtime-tokio` (native) or `runtime-wasm` (wasm32) \
+             to use ttl_sweep_interval / periodic refresh"
+        );
+    }
+
+    fn sleep(&self, _duration: Duration) -> BoxFut<'static> {
+        panic!(
+            "PunnuExecutor::sleep called without a runtime feature; \
+             enable `runtime-tokio` (native) or `runtime-wasm` (wasm32) \
+             to use ttl_sweep_interval / periodic refresh"
+        );
+    }
+
+    fn now(&self) -> Instant {
+        // Same target-aware alias as the runtime impls — see
+        // `crate::time::Instant`. Native = `tokio::time::Instant`,
+        // wasm = `web_time::Instant`. Tokio's `time` feature is in
+        // the workspace dep so `tokio::time::Instant::now()` works
+        // without any sassi runtime feature.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            tokio::time::Instant::now()
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            web_time::Instant::now()
+        }
+    }
+}

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -44,7 +44,7 @@ pub mod error;
 pub(crate) mod executor;
 pub mod predicate;
 pub mod punnu;
-pub(crate) mod time;
+mod time;
 
 pub use cacheable::{Cacheable, Field};
 pub use error::{BackendError, FetchError, InsertError};
@@ -53,6 +53,7 @@ pub use punnu::{
     BackendFailureMode, CacheTier, EventReason, InvalidationReason, OnConflict, Punnu,
     PunnuBuilder, PunnuConfig, PunnuEvent, PunnuMetrics, TenantKey,
 };
+pub use time::Instant;
 
 // Derive macro re-export. The trait and the derive share the name
 // `Cacheable` (different namespaces — type namespace for the trait,

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -41,8 +41,10 @@
 
 pub mod cacheable;
 pub mod error;
+pub(crate) mod executor;
 pub mod predicate;
 pub mod punnu;
+pub(crate) mod time;
 
 pub use cacheable::{Cacheable, Field};
 pub use error::{BackendError, InsertError};

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -47,7 +47,7 @@ pub mod punnu;
 pub(crate) mod time;
 
 pub use cacheable::{Cacheable, Field};
-pub use error::{BackendError, InsertError};
+pub use error::{BackendError, FetchError, InsertError};
 pub use predicate::{BasicPredicate, FieldPredicate, LookupOp};
 pub use punnu::{
     BackendFailureMode, CacheTier, EventReason, InvalidationReason, OnConflict, Punnu,

--- a/sassi/src/predicate/mod.rs
+++ b/sassi/src/predicate/mod.rs
@@ -6,7 +6,7 @@
 //!   `^`, `!` operators. Lowers cleanly to SQL when consumed by an ORM
 //!   that knows the `Field<T, V>` shape (e.g., djogi). Evaluates
 //!   identically against an in-memory `&T` via [`BasicPredicate::evaluate`].
-//! - `MemQ<T>` (lands in Cluster C, Task 11) — the in-memory-only
+//! - `MemQ<T>` (future extension) — the in-memory-only
 //!   extension. Adds closure predicates and trait-impl predicates that
 //!   can't be projected into SQL.
 //!

--- a/sassi/src/punnu/config.rs
+++ b/sassi/src/punnu/config.rs
@@ -17,20 +17,11 @@
 //! native consumer" — 10k-entry LRU, 256-event channel, L1-only on
 //! backend failure, last-write-wins on conflict, no TTL, no metrics.
 //!
-//! Several fields wire up across multiple tasks; their variants are
-//! pinned here so the config shape is stable from v0.1.0-alpha.0
-//! onward — adopters see the full surface, even though some hooks are
-//! not yet load-bearing. Each field's doc comment names the specific
-//! cluster/task that loads it:
-//!
-//! - [`PunnuConfig::default_ttl`] / [`PunnuConfig::ttl_sweep_interval`]
-//!   — already load-bearing in Cluster A, Task 6.
-//! - [`PunnuConfig::namespace`] — wired into `CacheBackend` keys in
-//!   Cluster D, Task 13.
-//! - [`PunnuConfig::metrics`] — hook called from `Punnu::insert` /
-//!   `get` / `invalidate` in Cluster B, Task 8.
-//! - [`PunnuConfig::backend_failure_mode`] — routing logic lives in
-//!   Cluster D, Task 13 (`CacheBackend` integration).
+//! Some fields are forward-compat pins for surfaces that are not yet
+//! load-bearing — adopters see the full config shape from
+//! v0.1.0-alpha.0 onward, even when the wire-up is deferred to a
+//! later release. Per-field doc comments mark whether each field is
+//! load-bearing today or reserved for a future integration.
 
 use crate::error::BackendError;
 use crate::punnu::events::EventReason;
@@ -67,8 +58,8 @@ pub struct PunnuConfig {
     /// What to do when an L2 backend write-through fails during
     /// [`crate::punnu::Punnu::insert`]. Default
     /// [`BackendFailureMode::L1Only`] — log the error, succeed against
-    /// L1 alone. Routing logic lives in Cluster D, Task 13
-    /// (`CacheBackend` integration).
+    /// L1 alone. Forward-compat pin: routing logic lands when the
+    /// `CacheBackend` integration ships.
     pub backend_failure_mode: BackendFailureMode,
 
     /// What to do when [`crate::punnu::Punnu::insert`] is called for an
@@ -97,7 +88,8 @@ pub struct PunnuConfig {
     /// production setups typically use `"prod_v1"` / `"staging_v1"`,
     /// and tests use a per-run UUID for parallel isolation. L1
     /// storage is unaffected — namespacing governs only L2 keys.
-    /// Wired into `CacheBackend` keys in Cluster D, Task 13.
+    /// Forward-compat pin: load-bearing once the `CacheBackend`
+    /// integration ships.
     pub namespace: Option<String>,
 
     /// Optional observability hook. When `Some`, every event of
@@ -107,8 +99,9 @@ pub struct PunnuConfig {
     /// metrics layer they already use (Prometheus, OpenTelemetry,
     /// statsd, …) without sassi pulling in a metrics framework.
     /// Default `None` is a no-op that costs nothing at runtime.
-    /// Hook called from `Punnu::insert` / `get` / `invalidate` in
-    /// Cluster B, Task 8.
+    /// Hook is called from [`crate::punnu::Punnu::get`] /
+    /// [`crate::punnu::Punnu::insert`] /
+    /// [`crate::punnu::Punnu::invalidate`].
     pub metrics: Option<Arc<dyn PunnuMetrics>>,
 }
 

--- a/sassi/src/punnu/events.rs
+++ b/sassi/src/punnu/events.rs
@@ -229,10 +229,11 @@ pub enum EventReason {
 
     /// System-internal: a distributed cache backend (Redis pub/sub,
     /// Postgres LISTEN/NOTIFY, …) pushed an invalidation that the
-    /// [`crate::punnu::Punnu`] applied locally. Pushed by the
-    /// `CacheBackend::invalidation_stream` consumer in Cluster D,
-    /// Task 13; pinned now so subscribers can pattern-match against
-    /// it from v0.1.0-alpha.0 onward. Not reachable via
+    /// [`crate::punnu::Punnu`] applied locally. Forward-compat pin:
+    /// the `CacheBackend::invalidation_stream` consumer hooks into
+    /// this variant when the future backend integration ships.
+    /// Pinned today so subscribers can pattern-match against it from
+    /// v0.1.0-alpha.0 onward. Not reachable via
     /// [`crate::punnu::Punnu::invalidate`]; sealed against external
     /// construction.
     #[non_exhaustive]

--- a/sassi/src/punnu/mod.rs
+++ b/sassi/src/punnu/mod.rs
@@ -17,6 +17,7 @@
 pub mod config;
 pub mod events;
 pub mod pool;
+pub(crate) mod single_flight;
 pub mod tenant;
 pub(crate) mod ttl;
 

--- a/sassi/src/punnu/mod.rs
+++ b/sassi/src/punnu/mod.rs
@@ -1,18 +1,10 @@
 //! [`Punnu<T>`] — typed in-memory pool with composable predicate
-//! filtering, an event stream, and (later tasks) single-flight fetch
-//! coalescing, opt-in TTL, and pluggable L2 backends.
+//! filtering, an event stream, single-flight fetch coalescing,
+//! opt-in TTL, and pluggable L2 backends.
 //!
 //! See the spec at `docs/superpowers/specs/2026-04-30-sassi-design.md`
 //! §3.5 for the public-API surface, §3.5.1 for the single-flight +
 //! per-process invariants, and §6 for the invalidation contract.
-//!
-//! # Cluster A scope
-//!
-//! This cluster (Tasks 4-6 of the v0.1.0 plan) lands the core pool
-//! shape: identity-map storage with LRU eviction, the broadcast event
-//! stream, and TTL-driven expiry (lazy + opt-in background sweep).
-//! Single-flight, scopes, backends, executors, refresh, and the
-//! orchestrator surface ship in subsequent clusters.
 
 pub mod config;
 pub mod events;

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -24,14 +24,16 @@
 //! so a sync lock under an async runtime is safe.
 
 use crate::cacheable::Cacheable;
-use crate::error::InsertError;
+use crate::error::{FetchError, InsertError};
 use crate::executor::{DefaultExecutor, PunnuExecutor};
 use crate::punnu::config::{OnConflict, PunnuConfig};
 use crate::punnu::events::{EventReason, InvalidationReason, PunnuEvent};
+use crate::punnu::single_flight::InFlightRegistry;
 use crate::punnu::ttl::Entry;
 #[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
 use crate::punnu::ttl::spawn_sweep;
 use lru::LruCache;
+use std::future::Future;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -109,6 +111,13 @@ pub(crate) struct PunnuInner<T: Cacheable> {
     /// <https://github.com/TarunvirBains/sassi/issues/4>.
     #[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
     pub(crate) sweep_initialised: Option<Arc<Notify>>,
+
+    /// Single-flight in-flight fetch registry — deduplicates
+    /// concurrent [`Punnu::get_or_fetch`] callers for the same id so
+    /// the consumer's fetcher closure runs exactly once per cold
+    /// fetch. See [`crate::punnu::single_flight`] for the cancellation
+    /// contract.
+    pub(crate) in_flight: InFlightRegistry<T>,
 }
 
 impl<T: Cacheable> Punnu<T> {
@@ -372,6 +381,190 @@ impl<T: Cacheable> Punnu<T> {
         }
     }
 
+    /// Get-or-fetch convenience for the lazy-fetch-on-miss pattern.
+    ///
+    /// On L1 hit, returns the cached `Arc<T>` immediately (no fetcher
+    /// invocation). On miss, calls `fetcher`; if it returns
+    /// `Some(value)`, inserts the value into L1 (so a subsequent
+    /// `get` is a hit) and returns `Some(arc)`. If the fetcher
+    /// returns `None`, the cache is left untouched and `None` is
+    /// returned — distinct from "fetch failed".
+    ///
+    /// # Single-flight coalescing (spec §3.5.1)
+    ///
+    /// Concurrent `get_or_fetch` calls for the same `id` deduplicate:
+    /// exactly one fetcher runs per cold fetch, even when N callers
+    /// race. Subsequent in-flight callers `await` the same
+    /// [`futures::future::Shared`] future. On completion the registry
+    /// slot is cleared and the result lands in L1.
+    ///
+    /// # Cancellation contract
+    ///
+    /// Four owner-loss cases, all deterministic:
+    ///
+    /// 1. **Originating caller drops, peers polling.** The fetch
+    ///    stays alive while ≥1 peer awaits.
+    /// 2. **All awaiters drop simultaneously.** Fetch is cancelled;
+    ///    registry slot is cleared. Subsequent calls retry from cold.
+    /// 3. **Fetcher panics.** Every awaiter receives
+    ///    [`crate::error::FetchError::FetcherPanic`]. The registry
+    ///    slot is cleared.
+    /// 4. **Caller-imposed deadline.** Punnu does not impose one.
+    ///    Wrap the call in `tokio::time::timeout(...)` for case 4 —
+    ///    that surfaces as case 1 from the registry's perspective.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use sassi::Punnu;
+    /// # struct User { id: i64 }
+    /// # impl sassi::Cacheable for User {
+    /// #     type Id = i64;
+    /// #     type Fields = UserFields;
+    /// #     fn id(&self) -> i64 { self.id }
+    /// #     fn fields() -> UserFields { UserFields }
+    /// # }
+    /// # #[derive(Default)] struct UserFields;
+    /// # async fn run(p: Punnu<User>) -> Result<(), sassi::FetchError> {
+    /// let user = p.get_or_fetch(&42, |id| async move {
+    ///     // Pretend this is a database call.
+    ///     Ok::<_, sassi::FetchError>(Some(User { id }))
+    /// }).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn get_or_fetch<F, Fut>(
+        &self,
+        id: &T::Id,
+        fetcher: F,
+    ) -> Result<Option<Arc<T>>, FetchError>
+    where
+        F: FnOnce(T::Id) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<Option<T>, FetchError>> + Send + 'static,
+    {
+        // L1 fast path — also runs the lazy TTL check via `get`.
+        if let Some(arc) = self.get(id) {
+            return Ok(Some(arc));
+        }
+
+        // Single-flight coalescing on miss. The registry returns
+        // `Arc<T>` when the fetcher returned `Some`; we then insert
+        // into L1 so the next `get` is a hit.
+        let result = self.inner.in_flight.get_or_fetch(id, fetcher).await?;
+
+        if let Some(arc) = &result {
+            // Insert through the standard path so `OnConflict`,
+            // events, and (later) metrics fire as if the consumer
+            // had called `insert` directly. We use `insert_arc` —
+            // see below — which avoids cloning the inner value.
+            self.insert_arc_into_l1(arc.clone()).await?;
+        }
+        Ok(result)
+    }
+
+    /// Batch get-or-fetch. Splits `ids` into "already cached"
+    /// (returned immediately) and "missing" (passed to
+    /// `batch_fetcher` as a single call). Avoids N round-trips when
+    /// the consumer naturally has a list of ids to resolve.
+    ///
+    /// # Single-flight semantics (v0.1)
+    ///
+    /// Within a single batch call, missing ids are deduplicated
+    /// before the batch fetcher is invoked (input may contain dupes).
+    /// Across concurrent batch calls, batch-level deduplication is
+    /// **not** implemented in v0.1 — two concurrent
+    /// `get_or_fetch_many(&[1, 2, 3])` calls invoke the batch fetcher
+    /// twice for the same set. Per-id single-flight coalescing across
+    /// concurrent *individual* `get_or_fetch` calls still applies as
+    /// usual; only the batch path skips the cross-batch dedup.
+    ///
+    /// Tracked as a v0.2 enhancement.
+    ///
+    /// # Result ordering
+    ///
+    /// The returned `Vec<Arc<T>>` does **not** preserve the input
+    /// `ids` order. Hits come first (in the order they were found
+    /// in L1), then fetched entries (in the order the batch fetcher
+    /// returned them). Consumers needing positional lookup should
+    /// build a `HashMap<T::Id, Arc<T>>` from the result.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use sassi::Punnu;
+    /// # struct User { id: i64 }
+    /// # impl sassi::Cacheable for User {
+    /// #     type Id = i64;
+    /// #     type Fields = UserFields;
+    /// #     fn id(&self) -> i64 { self.id }
+    /// #     fn fields() -> UserFields { UserFields }
+    /// # }
+    /// # #[derive(Default)] struct UserFields;
+    /// # async fn run(p: Punnu<User>) -> Result<(), sassi::FetchError> {
+    /// let users = p.get_or_fetch_many(&[1, 2, 3, 4, 5], |missing| async move {
+    ///     // Pretend this is one batched DB call.
+    ///     Ok::<_, sassi::FetchError>(missing.into_iter().map(|id| User { id }).collect())
+    /// }).await?;
+    /// # let _ = users; Ok(()) }
+    /// ```
+    pub async fn get_or_fetch_many<F, Fut>(
+        &self,
+        ids: &[T::Id],
+        batch_fetcher: F,
+    ) -> Result<Vec<Arc<T>>, FetchError>
+    where
+        F: FnOnce(Vec<T::Id>) -> Fut + Send,
+        Fut: Future<Output = Result<Vec<T>, FetchError>> + Send,
+    {
+        // Split cached vs missing. We dedup the `missing` list so the
+        // batch fetcher isn't asked for the same id twice within one
+        // call (consumers may pass dupes; batch backends rarely
+        // dedupe themselves).
+        let mut hits = Vec::new();
+        let mut missing: Vec<T::Id> = Vec::new();
+        let mut seen_missing: std::collections::HashSet<T::Id> = std::collections::HashSet::new();
+        for id in ids {
+            if let Some(arc) = self.get(id) {
+                hits.push(arc);
+            } else if seen_missing.insert(id.clone()) {
+                missing.push(id.clone());
+            }
+        }
+
+        if missing.is_empty() {
+            return Ok(hits);
+        }
+
+        // One batch fetch covers every missing id. Cross-batch
+        // dedup is documented as a v0.2 enhancement above.
+        let fetched = batch_fetcher(missing).await?;
+        let mut fetched_arcs = Vec::with_capacity(fetched.len());
+        for value in fetched {
+            // Route through the public `insert` path so OnConflict,
+            // event emission, and (later) metrics fire as if the
+            // consumer had inserted manually.
+            let arc = self.insert(value).await?;
+            fetched_arcs.push(arc);
+        }
+        hits.extend(fetched_arcs);
+        Ok(hits)
+    }
+
+    /// Insert a pre-built `Arc<T>` into L1 without cloning the
+    /// inner value. Used by [`Punnu::get_or_fetch`] after a
+    /// single-flight fetch — the fetcher returns `T`, single-flight
+    /// wraps it in an `Arc<T>` for cheap multi-awaiter sharing, and
+    /// this method threads the arc into L1 with the same OnConflict
+    /// + event-emission semantics as [`Punnu::insert`].
+    ///
+    /// `pub(crate)` because consumers should use `insert` (which
+    /// handles boxing); this is the internal escape hatch for the
+    /// single-flight path.
+    pub(crate) async fn insert_arc_into_l1(&self, arc: Arc<T>) -> Result<(), InsertError> {
+        let ttl = self.inner.config.default_ttl;
+        self.insert_arc_internal(arc, ttl).await?;
+        Ok(())
+    }
+
     /// Number of entries currently in the L1.
     ///
     /// Snapshots the current size; concurrent inserts / invalidates
@@ -553,6 +746,7 @@ impl<T: Cacheable> PunnuBuilder<T> {
             executor,
             #[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
             sweep_initialised: sweep_initialised.clone(),
+            in_flight: InFlightRegistry::new(),
         });
 
         // Spawn the sweep before constructing the public handle so

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -79,8 +79,8 @@ impl<T: Cacheable> Clone for Punnu<T> {
 /// Internal shared state — held behind `Arc` so `Punnu<T>` is cheaply
 /// cloneable.
 ///
-/// `pub(crate)` so the sweep task (Task 6) and the scope handle (Task
-/// 11) can observe state directly without going through `Punnu<T>`.
+/// `pub(crate)` so the sweep task and the (future) scope handle can
+/// observe state directly without going through `Punnu<T>`.
 pub(crate) struct PunnuInner<T: Cacheable> {
     /// L1 identity map. See module-level docs for the lock choice
     /// rationale.
@@ -504,12 +504,16 @@ impl<T: Cacheable> Punnu<T> {
         //
         // `on_fetched` returns the canonical `Arc<T>`: the freshly-
         // fetched one on the success path, or the already-cached
-        // value when `OnConflict::Reject` collides with an in-place
-        // entry (some other writer beat us to it during the fetch).
-        // The cache acts as if the user's intent — "ensure the cache
-        // has something at this id" — were satisfied either way.
+        // value when a non-expired entry beat us to the slot during
+        // the fetch. The atomic `insert_arc_or_existing` handles
+        // both the "fresh insert" and "existing entry, return it"
+        // cases under one L1 write lock — no expired-conflict race.
+        // `OnConflict` policy does not apply on this path:
+        // `get_or_fetch`'s contract is "ensure the cache has
+        // SOMETHING at this id, return it," not "follow the
+        // configured insert policy on a fresh fetch."
         let inner_weak = Arc::downgrade(&self.inner);
-        let on_fetched = move |id: T::Id, arc: Arc<T>| {
+        let on_fetched = move |_id: T::Id, arc: Arc<T>| {
             let inner_weak = inner_weak.clone();
             async move {
                 // If the Punnu was dropped during the fetch, just
@@ -519,22 +523,7 @@ impl<T: Cacheable> Punnu<T> {
                 let Some(inner) = inner_weak.upgrade() else {
                     return arc;
                 };
-                let punnu = Punnu { inner };
-                match punnu.insert_arc_into_l1(arc.clone()).await {
-                    Ok(()) => arc,
-                    Err(InsertError::Conflict) => {
-                        // Someone else inserted at this id while we
-                        // were fetching. The cache already has
-                        // something for the user. Return it.
-                        punnu.get(&id).unwrap_or(arc)
-                    }
-                    // `Serialization` and `BackendFailed` are
-                    // unreachable in v0.1 (no backend wired yet);
-                    // when Cluster D lands `CacheBackend`, surface
-                    // those errors back as `FetchError::Insert(...)`.
-                    // For now keep the fetched Arc.
-                    Err(_other) => arc,
-                }
+                Punnu { inner }.insert_arc_or_existing(arc).await
             }
         };
         let result = self
@@ -647,10 +636,95 @@ impl<T: Cacheable> Punnu<T> {
     /// `pub(crate)` because consumers should use `insert` (which
     /// handles boxing); this is the internal escape hatch for the
     /// single-flight path.
-    pub(crate) async fn insert_arc_into_l1(&self, arc: Arc<T>) -> Result<(), InsertError> {
+    /// Single-flight insert variant: insert `arc` into L1 if the slot
+    /// is empty *or holds an expired entry*; otherwise return the
+    /// already-cached non-expired `Arc<T>`. Atomic under one L1 write
+    /// lock — no expired-conflict race window.
+    ///
+    /// Used by [`Punnu::get_or_fetch`]'s `on_fetched` callback.
+    /// Resolves the BLOCK-M2 corner case where the consumer's
+    /// `OnConflict::Reject` policy collides with an entry that is
+    /// expired but not yet lazily popped: the standard `insert` path
+    /// would reject; this method treats expired entries as "absent"
+    /// and inserts the freshly-fetched value, satisfying
+    /// `get_or_fetch`'s documented post-condition that a subsequent
+    /// `get` hits.
+    ///
+    /// Returns the canonical `Arc<T>` — the freshly-inserted one if
+    /// the slot was empty/expired, the existing one if a non-expired
+    /// entry was present.
+    ///
+    /// `OnConflict` policy does not apply here. The behaviour is
+    /// always "insert if absent or expired; else return existing" —
+    /// `get_or_fetch`'s contract is "ensure the cache has SOMETHING
+    /// at this id, return it," not "follow the configured insert
+    /// policy."
+    pub(crate) async fn insert_arc_or_existing(&self, arc: Arc<T>) -> Arc<T> {
+        let id = arc.id();
         let ttl = self.inner.config.default_ttl;
-        self.insert_arc_internal(arc, ttl).await?;
-        Ok(())
+        let now = self.inner.executor.now();
+        let expires_at = ttl.map(|d| now + d);
+        let entry = Entry::with_expiry(arc.clone(), expires_at);
+
+        // Decision happens under a single write lock so the "is
+        // there a non-expired entry?" check + insert-if-not race-
+        // free. Return value is the canonical `Arc<T>` — the existing
+        // one if non-expired, the inserted one otherwise.
+        enum InsertOrExistingOutcome<T: Cacheable> {
+            ReturnedExisting(Arc<T>),
+            Inserted {
+                lru_evicted: Option<T::Id>,
+                post_len: usize,
+            },
+        }
+
+        let outcome = {
+            let mut map = self.inner.map.write().expect(
+                "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
+            );
+            match map.peek(&id) {
+                Some(existing) if !existing.is_expired_at(now) => {
+                    InsertOrExistingOutcome::ReturnedExisting(existing.value.clone())
+                }
+                _ => {
+                    // Slot empty OR existing entry is expired. Push the
+                    // fresh entry — `LruCache::push` replaces the
+                    // expired entry in place (or evicts a different
+                    // entry if at capacity).
+                    let pushed = map.push(id.clone(), entry);
+                    let post_len = map.len();
+                    let lru_evicted =
+                        pushed.and_then(|(k, _v)| if k != id { Some(k) } else { None });
+                    InsertOrExistingOutcome::Inserted {
+                        lru_evicted,
+                        post_len,
+                    }
+                }
+            }
+        };
+
+        match outcome {
+            InsertOrExistingOutcome::ReturnedExisting(existing) => existing,
+            InsertOrExistingOutcome::Inserted {
+                lru_evicted,
+                post_len,
+            } => {
+                // Emit events outside the lock.
+                if let Some(evicted_id) = lru_evicted {
+                    let _ = self.inner.events.send(PunnuEvent::Invalidate {
+                        id: evicted_id,
+                        reason: EventReason::LruEvict,
+                    });
+                    self.metrics_record_eviction(EventReason::LruEvict);
+                }
+                let _ = self
+                    .inner
+                    .events
+                    .send(PunnuEvent::Insert { value: arc.clone() });
+                self.metrics_record_lru_size(post_len);
+                arc
+            }
+        }
     }
 
     /// Number of entries currently in the L1.
@@ -691,10 +765,9 @@ impl<T: Cacheable> Punnu<T> {
         &self.inner.config
     }
 
-    // `scope()` (the predicate-driven query handle) lands in Task 11
-    // alongside the `MemQ<T>` extension algebra. Until then, callers
-    // compose with `Punnu::get` / iteration over `events()`. See
-    // `docs/superpowers/plans/2026-05-01-sassi-v0.1.0.md` Task 11.
+    // `scope()` (the predicate-driven query handle) is a future
+    // extension that pairs with the `MemQ<T>` algebra. Until then,
+    // callers compose with `Punnu::get` / iteration over `events()`.
 
     /// Test-only readiness handshake — resolves once the background
     /// TTL sweep task has been polled the first time and is parked on

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -26,7 +26,7 @@
 use crate::cacheable::Cacheable;
 use crate::error::{FetchError, InsertError};
 use crate::executor::{DefaultExecutor, PunnuExecutor};
-use crate::punnu::config::{OnConflict, PunnuConfig};
+use crate::punnu::config::{CacheTier, OnConflict, PunnuConfig};
 use crate::punnu::events::{EventReason, InvalidationReason, PunnuEvent};
 use crate::punnu::single_flight::InFlightRegistry;
 use crate::punnu::ttl::Entry;
@@ -212,7 +212,7 @@ impl<T: Cacheable> Punnu<T> {
 
         // Locking + push are pure in-memory work — no awaits while
         // holding the lock.
-        let outcome = {
+        let (outcome, post_len) = {
             let mut map = self.inner.map.write().expect(
                 "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
             );
@@ -232,10 +232,14 @@ impl<T: Cacheable> Punnu<T> {
             // eviction (k != inserted id). We disambiguate by
             // comparing keys.
             let pushed = map.push(id.clone(), entry);
-            InsertOutcome {
-                existing,
-                replaced_or_evicted: pushed,
-            }
+            let post_len = map.len();
+            (
+                InsertOutcome {
+                    existing,
+                    replaced_or_evicted: pushed,
+                },
+                post_len,
+            )
         };
 
         // Drop the lock before emitting events — broadcast `send`
@@ -252,6 +256,7 @@ impl<T: Cacheable> Punnu<T> {
                 id: evicted_id,
                 reason: EventReason::LruEvict,
             });
+            self.metrics_record_eviction(EventReason::LruEvict);
         }
 
         // Then emit the insert / update event, choosing the variant
@@ -267,6 +272,12 @@ impl<T: Cacheable> Punnu<T> {
             _ => PunnuEvent::Insert { value: arc.clone() },
         };
         let _ = self.inner.events.send(event);
+
+        // Sample the LRU size after every insert. Spec §3.5.1 calls
+        // this an opportunistic gauge — emit on a meaningful change
+        // (post-insert, post-invalidate) rather than streaming on
+        // every read.
+        self.metrics_record_lru_size(post_len);
 
         Ok(arc)
     }
@@ -295,12 +306,17 @@ impl<T: Cacheable> Punnu<T> {
     /// `TtlExpired` event fires for a given expired entry, even
     /// under contention.
     pub fn get(&self, id: &T::Id) -> Option<Arc<T>> {
-        // Fast path: peek first to avoid the write lock when the id
-        // is missing entirely. `peek` does not touch recency, so the
-        // lookup-on-hit path still needs the write lock — but a miss
-        // is the common cold-cache case, so the read-only peek is
-        // worth the branch.
-        let expired = {
+        // Three terminal outcomes — the locked block decides which:
+        // - hit: return Some(arc), record_hit
+        // - miss (id absent entirely): return None, record_miss
+        // - expired: pop, emit TtlExpired event, record_miss + record_eviction
+        enum GetOutcome<T> {
+            Hit(Arc<T>),
+            Miss,
+            Expired,
+        }
+
+        let outcome = {
             // Sample `now` once before taking the write lock so the
             // decision is consistent across the peek + pop without
             // re-reading the clock under the lock. `now` is a cheap
@@ -315,27 +331,49 @@ impl<T: Cacheable> Punnu<T> {
             // the value. If it's expired, pop it under the same
             // lock — that's the race-safe spot to decide who fires
             // `TtlExpired`.
-            let peeked = map.peek(id)?;
-            if peeked.is_expired_at(now) {
-                map.pop(id);
-                true
-            } else {
-                // `get` is guaranteed to find the entry — we just
-                // peeked it under the same write lock.
-                let entry = map
-                    .get(id)
-                    .expect("entry present (just peeked under same lock)");
-                return Some(entry.value.clone());
+            match map.peek(id) {
+                None => GetOutcome::Miss,
+                Some(peeked) => {
+                    if peeked.is_expired_at(now) {
+                        map.pop(id);
+                        GetOutcome::Expired
+                    } else {
+                        // `get` is guaranteed to find the entry — we
+                        // just peeked it under the same write lock.
+                        let entry = map
+                            .get(id)
+                            .expect("entry present (just peeked under same lock)");
+                        GetOutcome::Hit(entry.value.clone())
+                    }
+                }
             }
         };
 
-        if expired {
-            let _ = self.inner.events.send(PunnuEvent::Invalidate {
-                id: id.clone(),
-                reason: EventReason::TtlExpired,
-            });
+        match outcome {
+            GetOutcome::Hit(arc) => {
+                self.metrics_record_hit(CacheTier::L1);
+                Some(arc)
+            }
+            GetOutcome::Miss => {
+                self.metrics_record_miss();
+                None
+            }
+            GetOutcome::Expired => {
+                let _ = self.inner.events.send(PunnuEvent::Invalidate {
+                    id: id.clone(),
+                    reason: EventReason::TtlExpired,
+                });
+                // TTL-driven expiry counts as both an eviction (entry
+                // left the cache) and a miss (the get returned None).
+                // Dashboards typically split eviction by reason, so we
+                // emit both — eviction with TtlExpired and the miss
+                // counter. Aligns with spec §3.5.1's "metrics
+                // dashboards typically split by every reason".
+                self.metrics_record_eviction(EventReason::TtlExpired);
+                self.metrics_record_miss();
+                None
+            }
         }
-        None
     }
 
     /// Drop a single entry by id. No-op if the id is not cached.
@@ -367,17 +405,20 @@ impl<T: Cacheable> Punnu<T> {
     /// would defeat the public-vs-internal split that motivates the
     /// two enums.
     pub(crate) async fn invalidate_internal(&self, id: &T::Id, reason: EventReason) {
-        let removed = {
+        let (removed, post_len) = {
             let mut map = self.inner.map.write().expect(
                 "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
             );
-            map.pop(id).is_some()
+            let removed = map.pop(id).is_some();
+            (removed, map.len())
         };
         if removed {
             let _ = self.inner.events.send(PunnuEvent::Invalidate {
                 id: id.clone(),
                 reason,
             });
+            self.metrics_record_eviction(reason);
+            self.metrics_record_lru_size(post_len);
         }
     }
 
@@ -446,6 +487,14 @@ impl<T: Cacheable> Punnu<T> {
             return Ok(Some(arc));
         }
 
+        // Time the fetch path end-to-end (registry attach + fetcher
+        // run + L1 insert) so the latency includes coalescing
+        // overhead. Spec §3.5.1: `record_fetch_latency` fires for
+        // every `get_or_fetch` invocation that hits the slow path
+        // (L1 miss). Hits don't pay fetch latency, so they don't
+        // emit the histogram point.
+        let start = self.inner.executor.now();
+
         // Single-flight coalescing on miss. The registry returns
         // `Arc<T>` when the fetcher returned `Some`; we then insert
         // into L1 so the next `get` is a hit.
@@ -453,11 +502,15 @@ impl<T: Cacheable> Punnu<T> {
 
         if let Some(arc) = &result {
             // Insert through the standard path so `OnConflict`,
-            // events, and (later) metrics fire as if the consumer
-            // had called `insert` directly. We use `insert_arc` —
-            // see below — which avoids cloning the inner value.
+            // events, and metrics fire as if the consumer had called
+            // `insert` directly. `insert_arc_into_l1` avoids cloning
+            // the inner value.
             self.insert_arc_into_l1(arc.clone()).await?;
         }
+
+        let elapsed = self.inner.executor.now() - start;
+        self.metrics_record_fetch_latency(elapsed);
+
         Ok(result)
     }
 
@@ -627,6 +680,52 @@ impl<T: Cacheable> Punnu<T> {
     pub fn _test_sweep_initialised(&self) -> Option<Arc<Notify>> {
         self.inner.sweep_initialised.clone()
     }
+
+    // ---------------------------------------------------------------
+    // Metrics helpers — internal `record_*` shims that no-op when
+    // `PunnuConfig::metrics` is `None`. Wired from the call sites
+    // above (`get`, `insert_arc_internal`, `invalidate_internal`,
+    // `get_or_fetch`). The shim pattern:
+    //   - returns `()` so call sites can `.metrics_record_*()` on
+    //     `&self` with no error handling.
+    //   - reads `type_name` once via `std::any::type_name::<T>()`
+    //     (zero runtime cost; resolved at compile time per generic
+    //     instantiation). Spec §3.5.1 documents that `type_name` is
+    //     a metrics label, not a stable cross-version protocol id —
+    //     wire-format keys use a different identifier.
+    //   - the `if let Some(m) = ...` guard ensures the no-op path
+    //     compiles to a single null-check at the call site.
+    // ---------------------------------------------------------------
+
+    fn metrics_record_hit(&self, tier: CacheTier) {
+        if let Some(m) = &self.inner.config.metrics {
+            m.record_hit(std::any::type_name::<T>(), tier);
+        }
+    }
+
+    fn metrics_record_miss(&self) {
+        if let Some(m) = &self.inner.config.metrics {
+            m.record_miss(std::any::type_name::<T>());
+        }
+    }
+
+    fn metrics_record_eviction(&self, reason: EventReason) {
+        if let Some(m) = &self.inner.config.metrics {
+            m.record_eviction(std::any::type_name::<T>(), reason);
+        }
+    }
+
+    fn metrics_record_lru_size(&self, size: usize) {
+        if let Some(m) = &self.inner.config.metrics {
+            m.record_lru_size(std::any::type_name::<T>(), size);
+        }
+    }
+
+    fn metrics_record_fetch_latency(&self, duration: Duration) {
+        if let Some(m) = &self.inner.config.metrics {
+            m.record_fetch_latency(std::any::type_name::<T>(), duration);
+        }
+    }
 }
 
 /// Outcome of an `LruCache::push` pass — captured under the lock and
@@ -708,11 +807,15 @@ impl<T: Cacheable> PunnuBuilder<T> {
     /// - `config.lru_size == 0` — a zero-capacity LRU evicts every
     ///   insert immediately, which is a programmer error.
     /// - `config.ttl_sweep_interval == Some(Duration::ZERO)` — would
-    ///   reach `tokio::time::interval(0)` and panic at runtime. Use
-    ///   `None` to disable the sweep.
+    ///   reach the executor's `sleep(0)` in a tight loop. Use `None`
+    ///   to disable the sweep.
     /// - `config.event_channel_capacity == 0` — would reach
     ///   `broadcast::channel(0)` and panic at runtime. The minimum
     ///   sensible value is `1`.
+    /// - `config.namespace == Some(String::new())` — an empty string
+    ///   would silently prefix L2 backend keys with a leading
+    ///   separator and could collide with un-namespaced deployments.
+    ///   Use `None` to disable namespacing.
     pub fn build(self) -> Punnu<T> {
         let cap = NonZeroUsize::new(self.config.lru_size).unwrap_or_else(|| {
             panic!(
@@ -732,6 +835,15 @@ impl<T: Cacheable> PunnuBuilder<T> {
             "PunnuConfig::event_channel_capacity must be greater than 0; \
              the broadcast channel rejects a zero capacity"
         );
+        if let Some(ns) = &self.config.namespace {
+            assert!(
+                !ns.is_empty(),
+                "PunnuConfig::namespace must be non-empty when set; \
+                 use None to disable namespacing. An empty string would silently \
+                 prefix L2 backend keys with a leading separator and could collide \
+                 with un-namespaced deployments."
+            );
+        }
         let sweep_interval = self.config.ttl_sweep_interval;
         let (events, _) = broadcast::channel(self.config.event_channel_capacity);
         let executor: Arc<dyn PunnuExecutor> = Arc::new(DefaultExecutor);

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -495,18 +495,53 @@ impl<T: Cacheable> Punnu<T> {
         // emit the histogram point.
         let start = self.inner.executor.now();
 
-        // Single-flight coalescing on miss. The registry returns
-        // `Arc<T>` when the fetcher returned `Some`; we then insert
-        // into L1 so the next `get` is a hit.
-        let result = self.inner.in_flight.get_or_fetch(id, fetcher).await?;
-
-        if let Some(arc) = &result {
-            // Insert through the standard path so `OnConflict`,
-            // events, and metrics fire as if the consumer had called
-            // `insert` directly. `insert_arc_into_l1` avoids cloning
-            // the inner value.
-            self.insert_arc_into_l1(arc.clone()).await?;
-        }
+        // Single-flight coalescing on miss. The L1 insert runs
+        // **inside** the shared future body via the `on_fetched`
+        // callback — exactly once per fetch, regardless of how many
+        // peers attached. Without this, every coalesced peer would
+        // re-run `insert_arc_into_l1` after the await, multiplying
+        // events / TTL deadlines / OnConflict evaluations.
+        //
+        // `on_fetched` returns the canonical `Arc<T>`: the freshly-
+        // fetched one on the success path, or the already-cached
+        // value when `OnConflict::Reject` collides with an in-place
+        // entry (some other writer beat us to it during the fetch).
+        // The cache acts as if the user's intent — "ensure the cache
+        // has something at this id" — were satisfied either way.
+        let inner_weak = Arc::downgrade(&self.inner);
+        let on_fetched = move |id: T::Id, arc: Arc<T>| {
+            let inner_weak = inner_weak.clone();
+            async move {
+                // If the Punnu was dropped during the fetch, just
+                // return the freshly-fetched Arc — it'll never reach
+                // L1, but the originating caller still sees their
+                // value.
+                let Some(inner) = inner_weak.upgrade() else {
+                    return arc;
+                };
+                let punnu = Punnu { inner };
+                match punnu.insert_arc_into_l1(arc.clone()).await {
+                    Ok(()) => arc,
+                    Err(InsertError::Conflict) => {
+                        // Someone else inserted at this id while we
+                        // were fetching. The cache already has
+                        // something for the user. Return it.
+                        punnu.get(&id).unwrap_or(arc)
+                    }
+                    // `Serialization` and `BackendFailed` are
+                    // unreachable in v0.1 (no backend wired yet);
+                    // when Cluster D lands `CacheBackend`, surface
+                    // those errors back as `FetchError::Insert(...)`.
+                    // For now keep the fetched Arc.
+                    Err(_other) => arc,
+                }
+            }
+        };
+        let result = self
+            .inner
+            .in_flight
+            .get_or_fetch(id, fetcher, on_fetched)
+            .await?;
 
         let elapsed = self.inner.executor.now() - start;
         self.metrics_record_fetch_latency(elapsed);
@@ -829,6 +864,24 @@ impl<T: Cacheable> PunnuBuilder<T> {
                 "PunnuConfig::ttl_sweep_interval must be greater than Duration::ZERO; \
                  use None to disable the background sweep"
             );
+            // Without a runtime feature, we have no spawn primitive
+            // for the sweep task. Silently no-op'ing the user's opt-in
+            // would mean expired entries never evict and the sweep's
+            // promised events / metrics never fire — the spec would
+            // be lying to the consumer. Fail loudly at build time
+            // with a clear remediation pointer.
+            #[cfg(not(any(feature = "runtime-tokio", feature = "runtime-wasm")))]
+            {
+                let _ = d;
+                panic!(
+                    "PunnuConfig::ttl_sweep_interval requires either the `runtime-tokio` \
+                     or `runtime-wasm` feature. Without a runtime, sassi has no spawn \
+                     primitive to drive the sweep task and silently discarding the \
+                     opt-in would lie about TTL behavior. Either enable a runtime \
+                     feature or set `ttl_sweep_interval` to `None` for lazy-only \
+                     TTL expiry on `get`."
+                );
+            }
         }
         assert!(
             self.config.event_channel_capacity > 0,

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -25,21 +25,19 @@
 
 use crate::cacheable::Cacheable;
 use crate::error::InsertError;
+use crate::executor::{DefaultExecutor, PunnuExecutor};
 use crate::punnu::config::{OnConflict, PunnuConfig};
 use crate::punnu::events::{EventReason, InvalidationReason, PunnuEvent};
 use crate::punnu::ttl::Entry;
-#[cfg(feature = "runtime-tokio")]
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
 use crate::punnu::ttl::spawn_sweep;
 use lru::LruCache;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
+use tokio::sync::Notify;
 use tokio::sync::broadcast;
-// `tokio::time::Instant` is a drop-in for `std::time::Instant` that
-// honours `tokio::time::pause()` / `advance()` in tests. See the same
-// rationale in `crate::punnu::ttl`. Production behaviour is unchanged
-// — both types read the system monotonic clock outside of `pause()`.
-use tokio::time::Instant;
 
 /// Typed in-memory pool — the cache primitive. See module-level docs
 /// for concurrency and identity-map contract.
@@ -93,6 +91,24 @@ pub(crate) struct PunnuInner<T: Cacheable> {
     /// Configuration captured at build time. Held by reference via
     /// [`Punnu::config`]; not mutated after construction.
     pub(crate) config: PunnuConfig,
+
+    /// Runtime primitives — `spawn`, `sleep`, `now`. Held as
+    /// `Arc<dyn PunnuExecutor>` so v0.2's
+    /// [`crate::punnu::PunnuConfig::executor`] field plugs in without
+    /// any internal refactor; v0.1 always populates this with
+    /// `Arc<DefaultExecutor>`. See spec §3.11 / §3.11.1.
+    pub(crate) executor: Arc<dyn PunnuExecutor>,
+
+    /// Readiness signal fired on the sweep task's first poll, *before*
+    /// the first sleep. Tests `await` this before
+    /// `tokio::time::advance(...)` to guarantee the sleep is
+    /// registered against the test's virtual clock. `None` when no
+    /// sweep is configured (the field is still allocated to keep the
+    /// struct shape stable; `pub(crate)` so the test-helper accessor
+    /// on `Punnu<T>` can reach it). Closes
+    /// <https://github.com/TarunvirBains/sassi/issues/4>.
+    #[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
+    pub(crate) sweep_initialised: Option<Arc<Notify>>,
 }
 
 impl<T: Cacheable> Punnu<T> {
@@ -182,7 +198,7 @@ impl<T: Cacheable> Punnu<T> {
         ttl: Option<Duration>,
     ) -> Result<Arc<T>, InsertError> {
         let id = arc.id();
-        let expires_at = ttl.map(|d| Instant::now() + d);
+        let expires_at = ttl.map(|d| self.inner.executor.now() + d);
         let entry = Entry::with_expiry(arc.clone(), expires_at);
 
         // Locking + push are pure in-memory work — no awaits while
@@ -276,6 +292,11 @@ impl<T: Cacheable> Punnu<T> {
         // is the common cold-cache case, so the read-only peek is
         // worth the branch.
         let expired = {
+            // Sample `now` once before taking the write lock so the
+            // decision is consistent across the peek + pop without
+            // re-reading the clock under the lock. `now` is a cheap
+            // monotonic read regardless of executor.
+            let now = self.inner.executor.now();
             let mut map = self.inner.map.write().expect(
                 "Punnu L1 lock poisoned — a previous panic left it in an inconsistent state",
             );
@@ -286,7 +307,7 @@ impl<T: Cacheable> Punnu<T> {
             // lock — that's the race-safe spot to decide who fires
             // `TtlExpired`.
             let peeked = map.peek(id)?;
-            if peeked.is_expired() {
+            if peeked.is_expired_at(now) {
                 map.pop(id);
                 true
             } else {
@@ -393,6 +414,26 @@ impl<T: Cacheable> Punnu<T> {
     // alongside the `MemQ<T>` extension algebra. Until then, callers
     // compose with `Punnu::get` / iteration over `events()`. See
     // `docs/superpowers/plans/2026-05-01-sassi-v0.1.0.md` Task 11.
+
+    /// Test-only readiness handshake — resolves once the background
+    /// TTL sweep task has been polled the first time and is parked on
+    /// its initial `executor.sleep(interval)`. Tests `await` this
+    /// before calling `tokio::time::advance(...)` so the sleep is
+    /// guaranteed to be registered against the test's virtual clock.
+    ///
+    /// Returns `None` when no sweep was configured
+    /// (`PunnuConfig::ttl_sweep_interval == None`) — the readiness
+    /// signal only exists when there's a sweep to be ready about.
+    ///
+    /// `#[doc(hidden)]` because this is a test-helper escape hatch,
+    /// not part of the v0.1 public surface. Tests in this crate
+    /// import it; downstream code shouldn't.
+    /// Closes <https://github.com/TarunvirBains/sassi/issues/4>.
+    #[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
+    #[doc(hidden)]
+    pub fn _test_sweep_initialised(&self) -> Option<Arc<Notify>> {
+        self.inner.sweep_initialised.clone()
+    }
 }
 
 /// Outcome of an `LruCache::push` pass — captured under the lock and
@@ -500,16 +541,29 @@ impl<T: Cacheable> PunnuBuilder<T> {
         );
         let sweep_interval = self.config.ttl_sweep_interval;
         let (events, _) = broadcast::channel(self.config.event_channel_capacity);
+        let executor: Arc<dyn PunnuExecutor> = Arc::new(DefaultExecutor);
+
+        #[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
+        let sweep_initialised = sweep_interval.map(|_| Arc::new(Notify::new()));
+
         let inner = Arc::new(PunnuInner {
             map: RwLock::new(LruCache::new(cap)),
             events,
             config: self.config,
+            executor,
+            #[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
+            sweep_initialised: sweep_initialised.clone(),
         });
 
         // Spawn the sweep before constructing the public handle so
         // the weak ref is captured against the same `Arc` we hand
         // back. With `runtime-tokio` off, the call site is a no-op.
-        spawn_sweep_if_configured(&inner, sweep_interval);
+        #[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
+        spawn_sweep_if_configured(&inner, sweep_interval, sweep_initialised);
+        #[cfg(not(any(feature = "runtime-tokio", feature = "runtime-wasm")))]
+        {
+            let _ = sweep_interval; // avoid unused warning
+        }
 
         Punnu { inner }
     }
@@ -518,20 +572,20 @@ impl<T: Cacheable> PunnuBuilder<T> {
 /// Spawn the TTL-sweep task when both the feature is enabled and the
 /// config requested a sweep interval. Pulled out of `build()` so the
 /// `cfg` gate is a single statement instead of branching the body.
-#[cfg(feature = "runtime-tokio")]
-fn spawn_sweep_if_configured<T: Cacheable>(inner: &Arc<PunnuInner<T>>, interval: Option<Duration>) {
-    if let Some(interval) = interval {
-        spawn_sweep(Arc::downgrade(inner), interval);
-    }
-}
-
-/// No-op when the `runtime-tokio` feature is off — the sweep cannot
-/// run without a runtime. Lazy expiry on `get` still works.
-#[cfg(not(feature = "runtime-tokio"))]
+///
+/// `sweep_initialised` is the readiness handshake the sweep fires on
+/// first poll; tests await it before advancing virtual time. `Some`
+/// iff `interval` is `Some` (1:1 invariant established at the call
+/// site in [`PunnuBuilder::build`]).
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
 fn spawn_sweep_if_configured<T: Cacheable>(
-    _inner: &Arc<PunnuInner<T>>,
-    _interval: Option<Duration>,
+    inner: &Arc<PunnuInner<T>>,
+    interval: Option<Duration>,
+    sweep_initialised: Option<Arc<Notify>>,
 ) {
+    if let (Some(interval), Some(notify)) = (interval, sweep_initialised) {
+        spawn_sweep(Arc::downgrade(inner), interval, notify);
+    }
 }
 
 impl<T: Cacheable> Default for PunnuBuilder<T> {

--- a/sassi/src/punnu/single_flight.rs
+++ b/sassi/src/punnu/single_flight.rs
@@ -1,0 +1,291 @@
+//! Single-flight fetch coalescing — the in-flight registry that
+//! deduplicates concurrent `get_or_fetch` calls for the same id.
+//!
+//! Spec §3.5.1 — without coalescing, a hot key (e.g., a user-id queried
+//! from N concurrent request handlers) generates N database
+//! round-trips on cold-start. With coalescing, exactly one fetch per
+//! id at any moment; subsequent callers `await` the same future via
+//! [`futures::future::Shared`].
+//!
+//! # Cancellation contract (the four owner-loss cases)
+//!
+//! From spec §3.5.1, all four must behave deterministically:
+//!
+//! 1. **Originating caller dropped, peers polling.** [`Shared`] keeps
+//!    the underlying fetch alive as long as ≥1 cloned handle exists.
+//!    The longest-lived peer drives the work; the dropped originator
+//!    simply stops receiving the result.
+//! 2. **All awaiters drop simultaneously.** The fetch future is
+//!    dropped; cancellation propagates through whatever the fetcher
+//!    was awaiting (cancellation-safe primitives —
+//!    `tokio_postgres::Client::query` is). Subsequent calls retry
+//!    from cold.
+//! 3. **Fetcher panics.** [`Shared::poll`] propagates the panic to
+//!    *every* awaiter. Each peer sees a
+//!    [`crate::error::FetchError::FetcherPanic`]. Sassi wraps the
+//!    fetcher in [`std::panic::AssertUnwindSafe`] +
+//!    [`futures::FutureExt::catch_unwind`] so the panic is translated
+//!    into a structured error variant rather than poisoning the
+//!    runtime.
+//! 4. **Fetcher exceeds caller-imposed deadline.** Punnu does not
+//!    impose a deadline; consumers wrap with `tokio::time::timeout`
+//!    at the call site (case 4 surfaces as case 1 from the registry's
+//!    perspective).
+//!
+//! # Implementation
+//!
+//! The registry is a [`dashmap::DashMap<T::Id, Weak<Shared<...>>>`].
+//! Each caller holds a strong [`Arc<Shared<...>>`]; the DashMap holds
+//! only a [`Weak`] reference. When all strong handles drop (case 2),
+//! the Weak dangles and the underlying fetch future is dropped — real
+//! cancellation, not just registry cleanup. A new caller for the same
+//! id observes the dead Weak (`upgrade()` returns `None`) and starts
+//! a fresh fetch. The dead entry is replaced atomically under the
+//! [`dashmap::mapref::entry::Entry`] API.
+//!
+//! Storing `Weak` rather than `Shared` directly is the key invariant —
+//! it's what makes case 2 actually drop the fetch future. If the
+//! DashMap held a `Shared` clone, that clone would be a strong
+//! reference on the future and case 2 would degrade to "fetch runs to
+//! completion with no observers, registry leaks until next call".
+
+use crate::cacheable::Cacheable;
+use crate::error::FetchError;
+use dashmap::DashMap;
+use futures::FutureExt;
+use futures::future::Shared;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
+use std::sync::{Arc, Weak};
+
+/// Result of a single-flight fetch — `Ok(Some(arc))` on hit,
+/// `Ok(None)` on "fetcher says doesn't exist", `Err(_)` on failure.
+pub(crate) type FetchOutput<T> = Result<Option<Arc<T>>, FetchError>;
+
+// `Result<Option<Arc<T>>, FetchError>` is not `Clone` because two of
+// `FetchError`'s variants (`Backend(BackendError::Other(Box<dyn ...>))`
+// and `Custom(Box<dyn ...>)`) hold `!Clone` boxed errors. `Shared`
+// requires the inner Future's `Output: Clone` so every awaiter
+// receives an independent copy. We can't make `BackendError` /
+// `FetchError` clone without breaking type identity, so the registry
+// stores a clone-friendly *render* of the error: structured variants
+// stay structured, boxed errors render to their `Display` form. The
+// originating caller receives a rendered copy too — that's the
+// documented contract; coalesced peers see exactly what the first
+// poller sees.
+type SharedOutput<T> = Result<Option<Arc<T>>, FetchErrorClone>;
+
+/// Clone-friendly render of [`FetchError`] used inside the
+/// [`Shared`] future. Sealed against external construction — only
+/// the single-flight path mints these.
+#[derive(Debug, Clone)]
+pub(crate) enum FetchErrorClone {
+    /// Render of `FetchError::Backend(BackendError::NotFound)`.
+    BackendNotFound,
+    /// Render of `FetchError::Backend(BackendError::Serialization(_))`.
+    BackendSerialization(String),
+    /// Render of `FetchError::Backend(BackendError::Network(_))`.
+    BackendNetwork(String),
+    /// Render of `FetchError::Backend(BackendError::Other(_))` — the
+    /// original boxed-error type identity is lost; the `Display`
+    /// output round-trips. Documented contract — see module docs.
+    BackendOtherRendered(String),
+    /// Round-trip of `FetchError::Serialization`.
+    Serialization(String),
+    /// Round-trip of `FetchError::FetcherPanic`.
+    FetcherPanic {
+        /// `std::any::type_name::<T>()`.
+        type_name: &'static str,
+        /// Best-effort panic message.
+        message: String,
+    },
+    /// Render of `FetchError::Custom` — `Display` output round-trips,
+    /// type identity is lost.
+    CustomRendered(String),
+    /// Render of `FetchError::Insert(InsertError)`. The fetch path
+    /// itself doesn't mint this variant; covered for symmetry if a
+    /// fetcher chooses to return an `InsertError` it observed
+    /// elsewhere.
+    InsertRendered(String),
+}
+
+impl From<FetchErrorClone> for FetchError {
+    fn from(value: FetchErrorClone) -> Self {
+        use crate::error::BackendError;
+        match value {
+            FetchErrorClone::BackendNotFound => FetchError::Backend(BackendError::NotFound),
+            FetchErrorClone::BackendSerialization(s) => {
+                FetchError::Backend(BackendError::Serialization(s))
+            }
+            FetchErrorClone::BackendNetwork(s) => FetchError::Backend(BackendError::Network(s)),
+            FetchErrorClone::BackendOtherRendered(s) => {
+                FetchError::Backend(BackendError::Other(Box::new(RenderedError(s))))
+            }
+            FetchErrorClone::Serialization(s) => FetchError::Serialization(s),
+            FetchErrorClone::FetcherPanic { type_name, message } => {
+                FetchError::FetcherPanic { type_name, message }
+            }
+            FetchErrorClone::CustomRendered(s) => FetchError::Custom(Box::new(RenderedError(s))),
+            FetchErrorClone::InsertRendered(s) => {
+                FetchError::Custom(Box::new(RenderedError(format!("insert during fetch: {s}"))))
+            }
+        }
+    }
+}
+
+/// String-rendered carrier for the lossy clone path. The original
+/// boxed type identity is lost; `Display` output round-trips.
+#[derive(Debug)]
+struct RenderedError(String);
+
+impl std::fmt::Display for RenderedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for RenderedError {}
+
+fn into_clone(err: FetchError) -> FetchErrorClone {
+    use crate::error::BackendError;
+    match err {
+        FetchError::Backend(BackendError::NotFound) => FetchErrorClone::BackendNotFound,
+        FetchError::Backend(BackendError::Serialization(s)) => {
+            FetchErrorClone::BackendSerialization(s)
+        }
+        FetchError::Backend(BackendError::Network(s)) => FetchErrorClone::BackendNetwork(s),
+        FetchError::Backend(BackendError::Other(e)) => {
+            FetchErrorClone::BackendOtherRendered(format!("{e}"))
+        }
+        FetchError::Serialization(s) => FetchErrorClone::Serialization(s),
+        FetchError::FetcherPanic { type_name, message } => {
+            FetchErrorClone::FetcherPanic { type_name, message }
+        }
+        FetchError::Custom(e) => FetchErrorClone::CustomRendered(format!("{e}")),
+        FetchError::Insert(e) => FetchErrorClone::InsertRendered(format!("{e}")),
+    }
+}
+
+/// The shared fetch payload. `Pin<Arc<...>>` so the Shared future is
+/// allocated once and clonable cheaply; the inner Shared drives the
+/// underlying fetcher.
+type SharedFetchFuture<T> = Shared<Pin<Box<dyn Future<Output = SharedOutput<T>> + Send>>>;
+
+/// Strong handle to an in-flight fetch. Cloning this attaches another
+/// awaiter; dropping every clone allows the underlying fetch future
+/// to be dropped (case 2 of the cancellation contract).
+type StrongFetch<T> = Arc<SharedFetchFuture<T>>;
+
+/// Weak handle stored in the registry. Upgrade to a `StrongFetch`
+/// to attach as another awaiter; if the upgrade fails, the previous
+/// fetch was abandoned and a new caller should register fresh.
+type WeakFetch<T> = Weak<SharedFetchFuture<T>>;
+
+/// In-flight fetch registry.
+///
+/// `pub(crate)` — wired through [`crate::punnu::pool::PunnuInner`] so
+/// `Punnu::get_or_fetch` can route through it without exposing the
+/// registry shape to consumers.
+pub(crate) struct InFlightRegistry<T: Cacheable> {
+    pending: DashMap<T::Id, WeakFetch<T>>,
+}
+
+impl<T: Cacheable> InFlightRegistry<T> {
+    /// Empty registry. Constructed once per `PunnuInner<T>`.
+    pub(crate) fn new() -> Self {
+        Self {
+            pending: DashMap::new(),
+        }
+    }
+
+    /// Run `fetcher` exactly once across concurrent calls for the same
+    /// `id`. Subsequent in-flight callers share the same Shared
+    /// future and observe the same result.
+    ///
+    /// Cancellation contract is documented at the module level.
+    pub(crate) async fn get_or_fetch<F, Fut>(&self, id: &T::Id, fetcher: F) -> FetchOutput<T>
+    where
+        F: FnOnce(T::Id) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<Option<T>, FetchError>> + Send + 'static,
+    {
+        // Atomic registration via the entry API: probe + insert under
+        // a single shard lock so two concurrent callers can't both
+        // think they're the originator. Re-asserting the lookup under
+        // the entry API closes the M1 read-then-mutate race window.
+        let strong: StrongFetch<T> = match self.pending.entry(id.clone()) {
+            dashmap::mapref::entry::Entry::Occupied(mut e) => match e.get().upgrade() {
+                Some(strong) => strong,
+                None => {
+                    // Stale entry — the previous fetch was abandoned
+                    // (case 2: all awaiters dropped). Replace it with
+                    // a fresh fetch under the same shard lock.
+                    let strong = build_fetch::<T, _, _>(id.clone(), fetcher);
+                    e.insert(Arc::downgrade(&strong));
+                    strong
+                }
+            },
+            dashmap::mapref::entry::Entry::Vacant(e) => {
+                let strong = build_fetch::<T, _, _>(id.clone(), fetcher);
+                e.insert(Arc::downgrade(&strong));
+                strong
+            }
+        };
+
+        // Clone the inner Shared so we can `.await` it. `Shared` is
+        // itself ref-counted; this is cheap. The strong `Arc` we
+        // hold (and `_strong_holder` below) keeps the underlying
+        // fetch future alive until either (a) it completes or (b)
+        // every awaiter drops — at which point the strong count of
+        // the `Arc` reaches zero and the inner Shared is dropped,
+        // dropping the fetch future. Real cancellation, no
+        // background-task leak.
+        let shared = (*strong).clone();
+        let _strong_holder = strong;
+
+        let out: SharedOutput<T> = shared.await;
+        out.map_err(FetchError::from)
+    }
+}
+
+/// Build a fresh fetch future for the given id + fetcher closure,
+/// wrap it in [`Shared`], and return the `Arc<Shared<...>>` strong
+/// handle. The caller stores `Arc::downgrade(...)` in the registry
+/// and holds the strong handle for its own awaiter.
+fn build_fetch<T, F, Fut>(id: T::Id, fetcher: F) -> StrongFetch<T>
+where
+    T: Cacheable,
+    F: FnOnce(T::Id) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<Option<T>, FetchError>> + Send + 'static,
+{
+    let type_name = std::any::type_name::<T>();
+    // `AssertUnwindSafe` + `catch_unwind` translate a panicking
+    // fetcher into a structured `FetcherPanic` variant rather than
+    // poisoning the Shared future. `Shared` already broadcasts
+    // panics, but the broadcast surfaces as a `BroadcastedPanic` the
+    // consumer can't pattern-match on; sassi promises a structured
+    // error type. `AssertUnwindSafe` is sound because the fetcher's
+    // borrow does not escape this future — any state the fetcher
+    // mutated before panicking is owned by it (the FnOnce closure)
+    // and is dropped along with the unwound stack.
+    let inner: Pin<Box<dyn Future<Output = SharedOutput<T>> + Send>> = Box::pin(async move {
+        let result = AssertUnwindSafe(async move { fetcher(id).await })
+            .catch_unwind()
+            .await;
+        match result {
+            Ok(Ok(opt)) => Ok(opt.map(Arc::new)),
+            Ok(Err(e)) => Err(into_clone(e)),
+            Err(panic_payload) => {
+                let message = if let Some(s) = panic_payload.downcast_ref::<String>() {
+                    s.clone()
+                } else if let Some(s) = panic_payload.downcast_ref::<&'static str>() {
+                    (*s).to_string()
+                } else {
+                    String::new()
+                };
+                Err(FetchErrorClone::FetcherPanic { type_name, message })
+            }
+        }
+    });
+    Arc::new(inner.shared())
+}

--- a/sassi/src/punnu/single_flight.rs
+++ b/sassi/src/punnu/single_flight.rs
@@ -18,8 +18,9 @@
 //! 2. **All awaiters drop simultaneously.** The fetch future is
 //!    dropped; cancellation propagates through whatever the fetcher
 //!    was awaiting (cancellation-safe primitives —
-//!    `tokio_postgres::Client::query` is). Subsequent calls retry
-//!    from cold.
+//!    `tokio_postgres::Client::query` is). The [`SlotGuard`] inside
+//!    the future runs its `Drop` impl, which removes the registry
+//!    entry. Subsequent calls retry from cold against an empty slot.
 //! 3. **Fetcher panics.** [`Shared::poll`] propagates the panic to
 //!    *every* awaiter. Each peer sees a
 //!    [`crate::error::FetchError::FetcherPanic`]. Sassi wraps the
@@ -32,22 +33,36 @@
 //!    at the call site (case 4 surfaces as case 1 from the registry's
 //!    perspective).
 //!
+//! # Side-effect ordering — single L1 insert per fetch
+//!
+//! When a fetcher returns `Some(value)`, the L1 insert runs **inside**
+//! the shared future body — exactly once per fetch — via the
+//! `on_fetched` callback the caller supplies. Coalesced peers then
+//! receive the canonical `Arc<T>` from the same Shared output; they
+//! do not re-run the insert (which would otherwise multiply events,
+//! TTL deadlines, and `OnConflict` policy evaluations across N peers).
+//!
 //! # Implementation
 //!
-//! The registry is a [`dashmap::DashMap<T::Id, Weak<Shared<...>>>`].
+//! The registry is an [`Arc<dashmap::DashMap<T::Id, Weak<Shared<...>>>>`].
 //! Each caller holds a strong [`Arc<Shared<...>>`]; the DashMap holds
 //! only a [`Weak`] reference. When all strong handles drop (case 2),
 //! the Weak dangles and the underlying fetch future is dropped — real
-//! cancellation, not just registry cleanup. A new caller for the same
-//! id observes the dead Weak (`upgrade()` returns `None`) and starts
-//! a fresh fetch. The dead entry is replaced atomically under the
-//! [`dashmap::mapref::entry::Entry`] API.
+//! cancellation, not just registry cleanup.
 //!
 //! Storing `Weak` rather than `Shared` directly is the key invariant —
 //! it's what makes case 2 actually drop the fetch future. If the
 //! DashMap held a `Shared` clone, that clone would be a strong
 //! reference on the future and case 2 would degrade to "fetch runs to
 //! completion with no observers, registry leaks until next call".
+//!
+//! Registry entries are cleaned up via [`SlotGuard`] — held inside the
+//! Shared future body and run on `Drop` (whether triggered by
+//! completion or all-awaiters cancellation). The guard uses
+//! [`DashMap::remove_if`] with [`Weak::ptr_eq`] so it only removes the
+//! entry when the registered Weak still points at our specific future
+//! — a fresh fetch (case 2 → new caller) that has already replaced the
+//! slot is left alone.
 
 use crate::cacheable::Cacheable;
 use crate::error::FetchError;
@@ -182,51 +197,103 @@ type StrongFetch<T> = Arc<SharedFetchFuture<T>>;
 /// fetch was abandoned and a new caller should register fresh.
 type WeakFetch<T> = Weak<SharedFetchFuture<T>>;
 
+/// Drop guard that removes the registry entry when the wrapped Shared
+/// future is dropped (whether via completion or all-awaiters
+/// cancellation). Held *inside* the boxed future so its lifetime is
+/// pegged to the future's; when the future drops, the guard runs.
+///
+/// The race-safety guarantee comes from [`DashMap::remove_if`]: the
+/// removal is conditional on the entry's `Weak` still pointing at our
+/// specific future. A fresh fetch (case 2 → new caller) that has
+/// already replaced the slot has a different `Weak` and is left
+/// alone.
+struct SlotGuard<T: Cacheable> {
+    pending: Arc<DashMap<T::Id, WeakFetch<T>>>,
+    id: T::Id,
+    self_weak: WeakFetch<T>,
+}
+
+impl<T: Cacheable> Drop for SlotGuard<T> {
+    fn drop(&mut self) {
+        // `remove_if` runs the predicate under the shard's write
+        // lock; the entry is removed iff the current Weak `ptr_eq`s
+        // ours. No TOCTOU window between check and remove.
+        self.pending.remove_if(&self.id, |_k, current_weak| {
+            Weak::ptr_eq(current_weak, &self.self_weak)
+        });
+    }
+}
+
 /// In-flight fetch registry.
 ///
 /// `pub(crate)` — wired through [`crate::punnu::pool::PunnuInner`] so
 /// `Punnu::get_or_fetch` can route through it without exposing the
 /// registry shape to consumers.
 pub(crate) struct InFlightRegistry<T: Cacheable> {
-    pending: DashMap<T::Id, WeakFetch<T>>,
+    pending: Arc<DashMap<T::Id, WeakFetch<T>>>,
 }
 
 impl<T: Cacheable> InFlightRegistry<T> {
     /// Empty registry. Constructed once per `PunnuInner<T>`.
     pub(crate) fn new() -> Self {
         Self {
-            pending: DashMap::new(),
+            pending: Arc::new(DashMap::new()),
         }
     }
 
     /// Run `fetcher` exactly once across concurrent calls for the same
-    /// `id`. Subsequent in-flight callers share the same Shared
-    /// future and observe the same result.
+    /// `id`, then run `on_fetched` exactly once on the resulting
+    /// `Arc<T>` to install it into L1. Subsequent in-flight callers
+    /// share the same Shared future and observe the same canonical
+    /// result; they do **not** re-run the insert (which would
+    /// otherwise multiply events / TTL deadlines / OnConflict
+    /// evaluations across N peers).
+    ///
+    /// `on_fetched` returns the canonical `Arc<T>` — usually the same
+    /// `Arc<T>` it received, but consumers may swap it for the
+    /// already-cached value when handling `OnConflict::Reject`
+    /// conflicts.
     ///
     /// Cancellation contract is documented at the module level.
-    pub(crate) async fn get_or_fetch<F, Fut>(&self, id: &T::Id, fetcher: F) -> FetchOutput<T>
+    pub(crate) async fn get_or_fetch<F, Fut, OnFetched, OnFetchedFut>(
+        &self,
+        id: &T::Id,
+        fetcher: F,
+        on_fetched: OnFetched,
+    ) -> FetchOutput<T>
     where
         F: FnOnce(T::Id) -> Fut + Send + 'static,
         Fut: Future<Output = Result<Option<T>, FetchError>> + Send + 'static,
+        OnFetched: FnOnce(T::Id, Arc<T>) -> OnFetchedFut + Send + 'static,
+        OnFetchedFut: Future<Output = Arc<T>> + Send + 'static,
     {
         // Atomic registration via the entry API: probe + insert under
         // a single shard lock so two concurrent callers can't both
         // think they're the originator. Re-asserting the lookup under
-        // the entry API closes the M1 read-then-mutate race window.
+        // the entry API closes the read-then-mutate race window.
         let strong: StrongFetch<T> = match self.pending.entry(id.clone()) {
             dashmap::mapref::entry::Entry::Occupied(mut e) => match e.get().upgrade() {
                 Some(strong) => strong,
                 None => {
                     // Stale entry — the previous fetch was abandoned
-                    // (case 2: all awaiters dropped). Replace it with
-                    // a fresh fetch under the same shard lock.
-                    let strong = build_fetch::<T, _, _>(id.clone(), fetcher);
+                    // (case 2: all awaiters dropped, but the SlotGuard
+                    // hasn't run yet OR ran but a concurrent caller
+                    // re-inserted between our `entry()` and the guard's
+                    // `remove_if`). Replace it with a fresh fetch
+                    // under the same shard lock.
+                    let strong = build_fetch::<T, _, _, _, _>(
+                        id.clone(),
+                        fetcher,
+                        on_fetched,
+                        &self.pending,
+                    );
                     e.insert(Arc::downgrade(&strong));
                     strong
                 }
             },
             dashmap::mapref::entry::Entry::Vacant(e) => {
-                let strong = build_fetch::<T, _, _>(id.clone(), fetcher);
+                let strong =
+                    build_fetch::<T, _, _, _, _>(id.clone(), fetcher, on_fetched, &self.pending);
                 e.insert(Arc::downgrade(&strong));
                 strong
             }
@@ -234,11 +301,12 @@ impl<T: Cacheable> InFlightRegistry<T> {
 
         // Clone the inner Shared so we can `.await` it. `Shared` is
         // itself ref-counted; this is cheap. The strong `Arc` we
-        // hold (and `_strong_holder` below) keeps the underlying
-        // fetch future alive until either (a) it completes or (b)
-        // every awaiter drops — at which point the strong count of
-        // the `Arc` reaches zero and the inner Shared is dropped,
-        // dropping the fetch future. Real cancellation, no
+        // hold (`_strong_holder` below) keeps the underlying fetch
+        // future alive until either (a) it completes or (b) every
+        // awaiter drops — at which point the strong count of the
+        // `Arc` reaches zero, the inner Shared is dropped, the boxed
+        // future is dropped, and the SlotGuard inside it runs Drop
+        // and clears the registry entry. Real cancellation, no
         // background-task leak.
         let shared = (*strong).clone();
         let _strong_holder = strong;
@@ -248,44 +316,84 @@ impl<T: Cacheable> InFlightRegistry<T> {
     }
 }
 
-/// Build a fresh fetch future for the given id + fetcher closure,
-/// wrap it in [`Shared`], and return the `Arc<Shared<...>>` strong
-/// handle. The caller stores `Arc::downgrade(...)` in the registry
-/// and holds the strong handle for its own awaiter.
-fn build_fetch<T, F, Fut>(id: T::Id, fetcher: F) -> StrongFetch<T>
+/// Build a fresh fetch future for the given id + fetcher closure +
+/// on_fetched callback, wrap it in [`Shared`], and return the
+/// `Arc<Shared<...>>` strong handle.
+///
+/// Uses [`Arc::new_cyclic`] so the [`SlotGuard`] inside the future
+/// body can capture its own `Weak<SharedFetchFuture<T>>` for the
+/// race-safe `remove_if`. The cyclic construction is sound because
+/// the closure is sync (Shared::new is sync; the async work is inside
+/// the boxed future, polled later).
+fn build_fetch<T, F, Fut, OnFetched, OnFetchedFut>(
+    id: T::Id,
+    fetcher: F,
+    on_fetched: OnFetched,
+    pending: &Arc<DashMap<T::Id, WeakFetch<T>>>,
+) -> StrongFetch<T>
 where
     T: Cacheable,
     F: FnOnce(T::Id) -> Fut + Send + 'static,
     Fut: Future<Output = Result<Option<T>, FetchError>> + Send + 'static,
+    OnFetched: FnOnce(T::Id, Arc<T>) -> OnFetchedFut + Send + 'static,
+    OnFetchedFut: Future<Output = Arc<T>> + Send + 'static,
 {
+    let pending = pending.clone();
     let type_name = std::any::type_name::<T>();
-    // `AssertUnwindSafe` + `catch_unwind` translate a panicking
-    // fetcher into a structured `FetcherPanic` variant rather than
-    // poisoning the Shared future. `Shared` already broadcasts
-    // panics, but the broadcast surfaces as a `BroadcastedPanic` the
-    // consumer can't pattern-match on; sassi promises a structured
-    // error type. `AssertUnwindSafe` is sound because the fetcher's
-    // borrow does not escape this future — any state the fetcher
-    // mutated before panicking is owned by it (the FnOnce closure)
-    // and is dropped along with the unwound stack.
-    let inner: Pin<Box<dyn Future<Output = SharedOutput<T>> + Send>> = Box::pin(async move {
-        let result = AssertUnwindSafe(async move { fetcher(id).await })
-            .catch_unwind()
-            .await;
-        match result {
-            Ok(Ok(opt)) => Ok(opt.map(Arc::new)),
-            Ok(Err(e)) => Err(into_clone(e)),
-            Err(panic_payload) => {
-                let message = if let Some(s) = panic_payload.downcast_ref::<String>() {
-                    s.clone()
-                } else if let Some(s) = panic_payload.downcast_ref::<&'static str>() {
-                    (*s).to_string()
-                } else {
-                    String::new()
-                };
-                Err(FetchErrorClone::FetcherPanic { type_name, message })
+    let id_for_guard = id.clone();
+    let id_for_fetch = id.clone();
+    let id_for_on_fetched = id;
+    let pending_for_guard = pending;
+
+    Arc::new_cyclic(move |self_weak: &WeakFetch<T>| {
+        let self_weak_for_guard = self_weak.clone();
+        // `AssertUnwindSafe` + `catch_unwind` translate a panicking
+        // fetcher into a structured `FetcherPanic` variant rather than
+        // poisoning the Shared future. `Shared` already broadcasts
+        // panics, but the broadcast surfaces as a `BroadcastedPanic` the
+        // consumer can't pattern-match on; sassi promises a structured
+        // error type. `AssertUnwindSafe` is sound because the fetcher's
+        // borrow does not escape this future — any state the fetcher
+        // mutated before panicking is owned by it (the FnOnce closure)
+        // and is dropped along with the unwound stack.
+        let inner: Pin<Box<dyn Future<Output = SharedOutput<T>> + Send>> = Box::pin(async move {
+            // Held for the whole future body. Drops on completion OR
+            // on all-awaiters cancellation; either way, the registry
+            // slot is cleared.
+            let _slot_guard = SlotGuard {
+                pending: pending_for_guard,
+                id: id_for_guard,
+                self_weak: self_weak_for_guard,
+            };
+
+            let result = AssertUnwindSafe(async move { fetcher(id_for_fetch).await })
+                .catch_unwind()
+                .await;
+            match result {
+                Ok(Ok(Some(value))) => {
+                    let arc = Arc::new(value);
+                    // Run the L1 insert exactly once, here, before
+                    // any awaiter receives the canonical Arc. The
+                    // callback returns the canonical value (the same
+                    // Arc on success, or the already-cached Arc on
+                    // OnConflict::Reject collision).
+                    let canonical = on_fetched(id_for_on_fetched, arc).await;
+                    Ok(Some(canonical))
+                }
+                Ok(Ok(None)) => Ok(None),
+                Ok(Err(e)) => Err(into_clone(e)),
+                Err(panic_payload) => {
+                    let message = if let Some(s) = panic_payload.downcast_ref::<String>() {
+                        s.clone()
+                    } else if let Some(s) = panic_payload.downcast_ref::<&'static str>() {
+                        (*s).to_string()
+                    } else {
+                        String::new()
+                    };
+                    Err(FetchErrorClone::FetcherPanic { type_name, message })
+                }
             }
-        }
-    });
-    Arc::new(inner.shared())
+        });
+        inner.shared()
+    })
 }

--- a/sassi/src/punnu/ttl.rs
+++ b/sassi/src/punnu/ttl.rs
@@ -195,11 +195,31 @@ pub(crate) fn spawn_sweep<T: Cacheable>(
                 to_remove
             };
 
+            // Record metrics outside the lock — `record_*` is a
+            // consumer-defined trait method that may do arbitrary
+            // work; we don't want it inside the L1 write-lock scope.
+            // Spec §3.5.1: TTL-driven evictions count, the dashboard
+            // splits by reason. We also sample `record_lru_size`
+            // once per sweep tick that removed anything (no-op when
+            // expired_ids is empty — the size didn't change).
+            let removed_count = expired_ids.len();
             for id in expired_ids {
                 let _ = inner.events.send(PunnuEvent::Invalidate {
                     id,
                     reason: EventReason::TtlExpired,
                 });
+                if let Some(m) = &inner.config.metrics {
+                    m.record_eviction(std::any::type_name::<T>(), EventReason::TtlExpired);
+                }
+            }
+            if removed_count > 0
+                && let Some(m) = &inner.config.metrics
+            {
+                let post_len = match inner.map.read() {
+                    Ok(g) => g.len(),
+                    Err(_) => continue,
+                };
+                m.record_lru_size(std::any::type_name::<T>(), post_len);
             }
         }
     }));

--- a/sassi/src/punnu/ttl.rs
+++ b/sassi/src/punnu/ttl.rs
@@ -13,9 +13,9 @@
 //! Two mechanisms enforce expiry:
 //!
 //! - **Lazy expiry on access.** Always active. [`Punnu::get`] checks
-//!   `expires_at <= Instant::now()`; if expired, removes the entry
-//!   from L1 and emits `PunnuEvent::Invalidate { reason: TtlExpired
-//!   }`. Cost: one comparison per `get`.
+//!   `expires_at <= now`; if expired, removes the entry from L1 and
+//!   emits `PunnuEvent::Invalidate { reason: TtlExpired }`. Cost: one
+//!   comparison per `get`.
 //! - **Background sweep.** Active iff
 //!   [`crate::punnu::PunnuConfig::ttl_sweep_interval`] is `Some`. Walks
 //!   the L1 every interval tick, removes anything already expired,
@@ -35,31 +35,25 @@
 //! - **Forward compatibility:** later metadata (per-entry `inserted_at`
 //!   for refresh hints, per-entry `tenant_origin` for cross-tenant
 //!   guard diagnostics, …) lands without changing every callsite.
-//! - **Discoverability:** `entry.is_expired()` reads better than
-//!   `entry.1.map(|t| t <= Instant::now()).unwrap_or(false)` and keeps
-//!   the comparison policy in one place.
+//! - **Discoverability:** `entry.is_expired_at(now)` reads better than
+//!   `entry.1.map(|t| t <= now).unwrap_or(false)` and keeps the
+//!   comparison policy in one place.
 //! - **Clone semantics:** `Entry<T>: Clone` cheaply because the
 //!   payload is `Arc<T>`; `Instant` is `Copy`. Cloning happens
 //!   on every `get` returning a sharable handle.
 
-#[cfg(feature = "runtime-tokio")]
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
 use crate::cacheable::Cacheable;
-#[cfg(feature = "runtime-tokio")]
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
 use crate::punnu::events::{EventReason, PunnuEvent};
-#[cfg(feature = "runtime-tokio")]
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
 use crate::punnu::pool::PunnuInner;
+use crate::time::Instant;
 use std::sync::Arc;
-#[cfg(feature = "runtime-tokio")]
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
 use std::sync::Weak;
-// `tokio::time::Instant` is a drop-in for `std::time::Instant` that
-// honours `tokio::time::pause()` / `advance()` in tests. Production
-// behaviour is identical — both types read the system monotonic clock
-// outside of `pause()`; test code that opts into
-// `#[tokio::test(start_paused = true)]` gets deterministic
-// virtual-time control over sassi's TTL bookkeeping. Tokio's `time`
-// feature is unconditionally enabled in the workspace, so this import
-// works for both `runtime-tokio` and the no-default-features build.
-use tokio::time::Instant;
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
+use tokio::sync::Notify;
 
 /// LRU storage cell — holds the cached payload plus per-entry
 /// metadata.
@@ -71,11 +65,12 @@ pub(crate) struct Entry<T> {
     pub value: Arc<T>,
 
     /// Absolute expiry deadline, computed from
-    /// `tokio::time::Instant::now() + ttl` at insert time. `None`
-    /// means the entry never expires on time (LRU eviction can still
-    /// drop it). `tokio::time::Instant` is a drop-in for
-    /// `std::time::Instant` that honours `tokio::time::pause` in
-    /// tests; production wall-clock semantics are unchanged.
+    /// `executor.now() + ttl` at insert time. `None` means the entry
+    /// never expires on time (LRU eviction can still drop it). The
+    /// [`Instant`] type is target-aware (see [`crate::time`]) — on
+    /// native it's `tokio::time::Instant` so test pause/advance is
+    /// honoured; on wasm it's `web_time::Instant` (browser
+    /// `Performance.now()`).
     pub expires_at: Option<Instant>,
 }
 
@@ -89,22 +84,14 @@ impl<T> Entry<T> {
 
     /// Has the entry's TTL elapsed against `now`?
     ///
-    /// Pure (no clock read) so callers can sample `Instant::now()`
-    /// once per sweep tick and reuse it across many entries — the
-    /// background sweep does exactly this.
+    /// Pure (no clock read) so callers can sample a `now` once per
+    /// sweep tick (or once per `get`) and reuse it across many
+    /// entries — the background sweep does exactly this.
     pub(crate) fn is_expired_at(&self, now: Instant) -> bool {
         match self.expires_at {
             Some(deadline) => deadline <= now,
             None => false,
         }
-    }
-
-    /// Has the entry's TTL elapsed against the current clock?
-    /// Convenience wrapper around `is_expired_at(Instant::now())` for
-    /// the lazy-expiry path on `get`, where there's no batched clock
-    /// to reuse.
-    pub(crate) fn is_expired(&self) -> bool {
-        self.is_expired_at(Instant::now())
     }
 }
 
@@ -119,30 +106,65 @@ impl<T> Clone for Entry<T> {
     }
 }
 
-/// Spawn the background sweep task on the tokio runtime.
+/// Spawn the background sweep task via the [`PunnuExecutor`]
+/// abstraction.
 ///
 /// Cancellation is handled via the [`Weak`] reference: when every
 /// `Punnu<T>` clone drops, the strong count of `PunnuInner<T>` falls
 /// to zero, `weak.upgrade()` returns `None`, and the loop exits
-/// cleanly. No explicit handle, no `JoinHandle` to drop, no
-/// `Notify` — the cancellation primitive is owner-loss itself.
+/// cleanly. No explicit handle, no `JoinHandle` to drop — the
+/// cancellation primitive is owner-loss itself.
 ///
-/// Direct `tokio::spawn` here is wasm-incompatible; refactored
-/// through `PunnuExecutor` in Cluster B, Task 10. WASM consumers
-/// that opt in to TTL with `ttl_sweep_interval = Some(_)` need that
-/// executor abstraction. Tracked at
-/// <https://github.com/TarunvirBains/sassi/issues/3>.
-#[cfg(feature = "runtime-tokio")]
-pub(crate) fn spawn_sweep<T: Cacheable>(weak: Weak<PunnuInner<T>>, interval: std::time::Duration) {
-    tokio::spawn(async move {
-        let mut tick = tokio::time::interval(interval);
-        // Skip the first immediate tick — `interval` fires once at t=0
-        // by default, which would sweep before any insert lands.
-        // `Burst` is the default `MissedTickBehavior` and is fine
-        // here; we just prefer to start the cadence at +interval.
-        tick.tick().await;
+/// # Determinism handshake
+///
+/// `sweep_initialised` is fired exactly once on the sweep task's
+/// first poll, *before* the first sleep. Tests can `await` that
+/// signal before calling `tokio::time::advance(...)` — the sleep is
+/// guaranteed to be registered against the test's virtual clock at
+/// that point. Replaces the `tokio::task::yield_now` heuristic from
+/// Cluster A; closes <https://github.com/TarunvirBains/sassi/issues/4>.
+///
+/// # Cross-target spawn
+///
+/// Calls `inner.executor.spawn(...)` — on native that's
+/// `tokio::spawn`; on wasm it's `wasm_bindgen_futures::spawn_local`.
+/// The sleep is similarly routed through `executor.sleep`. The sweep
+/// body itself is runtime-agnostic.
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-wasm"))]
+pub(crate) fn spawn_sweep<T: Cacheable>(
+    weak: Weak<PunnuInner<T>>,
+    interval: std::time::Duration,
+    sweep_initialised: Arc<Notify>,
+) {
+    // Pre-spawn upgrade to capture the executor handle. If the inner
+    // has already been dropped between `build()` and here, there is
+    // nothing to sweep — return without spawning.
+    let Some(inner_for_exec) = weak.upgrade() else {
+        return;
+    };
+    let executor = inner_for_exec.executor.clone();
+    drop(inner_for_exec);
+
+    let exec_for_loop = executor.clone();
+    executor.spawn(Box::pin(async move {
+        // Fire the readiness signal on first poll, before any sleep.
+        // This is the deterministic handshake that replaces the
+        // yield-count heuristic — tests await this notification
+        // before advancing virtual time, ensuring the first sleep is
+        // registered against the test's clock.
+        //
+        // `notify_one()` (not `notify_waiters()`) so the signal is
+        // race-free: if the test calls `_test_sweep_initialised`
+        // *after* the sweep task has already ticked through this
+        // line, the stored permit is consumed by the next
+        // `notified()` call. `notify_waiters()` would silently drop
+        // the wake-up in that ordering. Only one waiter consumes it
+        // — that matches the test expectation (one prime_sweep call
+        // per Punnu).
+        sweep_initialised.notify_one();
+
         loop {
-            tick.tick().await;
+            exec_for_loop.sleep(interval).await;
 
             // Upgrade once per tick. If every Punnu<T> clone has
             // dropped, the inner is gone and we exit cleanly.
@@ -160,7 +182,7 @@ pub(crate) fn spawn_sweep<T: Cacheable>(weak: Weak<PunnuInner<T>>, interval: std
                     // public API surface returns the same poison.
                     Err(_) => break,
                 };
-                let now = Instant::now();
+                let now = inner.executor.now();
                 let mut to_remove = Vec::new();
                 for (id, entry) in map.iter() {
                     if entry.is_expired_at(now) {
@@ -180,5 +202,5 @@ pub(crate) fn spawn_sweep<T: Cacheable>(weak: Weak<PunnuInner<T>>, interval: std
                 });
             }
         }
-    });
+    }));
 }

--- a/sassi/src/punnu/ttl.rs
+++ b/sassi/src/punnu/ttl.rs
@@ -121,8 +121,8 @@ impl<T> Clone for Entry<T> {
 /// first poll, *before* the first sleep. Tests can `await` that
 /// signal before calling `tokio::time::advance(...)` — the sleep is
 /// guaranteed to be registered against the test's virtual clock at
-/// that point. Replaces the `tokio::task::yield_now` heuristic from
-/// Cluster A; closes <https://github.com/TarunvirBains/sassi/issues/4>.
+/// that point. Replaces the previous `tokio::task::yield_now`
+/// heuristic; closes <https://github.com/TarunvirBains/sassi/issues/4>.
 ///
 /// # Cross-target spawn
 ///

--- a/sassi/src/time.rs
+++ b/sassi/src/time.rs
@@ -1,0 +1,46 @@
+//! Cross-target monotonic-clock alias.
+//!
+//! Sassi reads the clock in three places: TTL deadline computation at
+//! insert (`expires_at = now() + ttl`), lazy-expiry comparison on
+//! `get` (`expires_at <= now()`), and the background sweep tick. To
+//! compile cleanly on both native and `wasm32-unknown-unknown`
+//! without `cfg`-branching every call site, sassi exposes a single
+//! [`Instant`] type alias that resolves per target.
+//!
+//! # Native
+//!
+//! On native (`not(target_arch = "wasm32")`), [`Instant`] is
+//! [`tokio::time::Instant`] — a drop-in for
+//! [`std::time::Instant`] that honours
+//! [`tokio::time::pause()`] / [`tokio::time::advance()`]. This
+//! matters for sassi's TTL test suite, which runs under
+//! `#[tokio::test(start_paused = true)]` and drives virtual time
+//! deterministically. Production wall-clock semantics are unchanged
+//! — outside of `pause()`, `tokio::time::Instant` reads the same
+//! monotonic clock as `std::time::Instant`.
+//!
+//! # Wasm
+//!
+//! On `wasm32-unknown-unknown`, [`Instant`] is
+//! [`web_time::Instant`] — a wrapper around the browser's
+//! `Performance.now()` API that exposes a `std::time::Instant`-shaped
+//! interface. `tokio::time::Instant` is not used on wasm because
+//! tokio's timer runtime (and `tokio::time::pause`) doesn't run there;
+//! `web_time::Instant` gives wasm consumers a working monotonic clock
+//! without any runtime dependency.
+//!
+//! # Why an alias rather than a wrapper struct
+//!
+//! Both `tokio::time::Instant` and `web_time::Instant` mirror the
+//! `std::time::Instant` API (arithmetic with `Duration`, ordering,
+//! `Copy`). Sassi only uses the shared subset, so a type alias is
+//! sufficient — wrapping would add boilerplate without buying
+//! anything. If a future operation needs target-specific behaviour,
+//! we can promote to a newtype then; today the alias is the smaller,
+//! more honest choice.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) type Instant = tokio::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) type Instant = web_time::Instant;

--- a/sassi/src/time.rs
+++ b/sassi/src/time.rs
@@ -39,8 +39,17 @@
 //! we can promote to a newtype then; today the alias is the smaller,
 //! more honest choice.
 
+/// Cross-target monotonic clock instant. See module-level docs.
+///
+/// Native (`not(target_arch = "wasm32")`): [`tokio::time::Instant`] —
+/// honours `tokio::time::pause()` / `advance()` for deterministic
+/// test clocks.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) type Instant = tokio::time::Instant;
+pub type Instant = tokio::time::Instant;
 
+/// Cross-target monotonic clock instant. See module-level docs.
+///
+/// `wasm32-unknown-unknown`: [`web_time::Instant`] — wraps the
+/// browser's `Performance.now()` API.
 #[cfg(target_arch = "wasm32")]
-pub(crate) type Instant = web_time::Instant;
+pub type Instant = web_time::Instant;

--- a/sassi/tests/punnu_events.rs
+++ b/sassi/tests/punnu_events.rs
@@ -1,4 +1,4 @@
-//! Task 5 — `Punnu<T>` event stream coverage.
+//! `Punnu<T>` event stream coverage.
 //!
 //! Exercises the four event-related contracts:
 //!
@@ -10,8 +10,8 @@
 //!   `RecvError::Lagged` rather than crashing the producer (spec §3.5
 //!   lossy-by-design contract)
 //!
-//! Implementation lives in Task 4 (`pool.rs`); this file is the
-//! observability test surface.
+//! Implementation lives in `pool.rs`; this file is the observability
+//! test surface.
 
 use sassi::{
     Cacheable, EventReason, Field, InvalidationReason, OnConflict, Punnu, PunnuConfig, PunnuEvent,

--- a/sassi/tests/punnu_executor_default.rs
+++ b/sassi/tests/punnu_executor_default.rs
@@ -1,4 +1,4 @@
-//! Task 10 — `DefaultExecutor` smoke test on the tokio runtime.
+//! `DefaultExecutor` smoke test on the tokio runtime.
 //!
 //! `PunnuExecutor` is `pub(crate)` in v0.1; this test exercises it
 //! indirectly through the public surface. The interesting end-to-end
@@ -7,9 +7,8 @@
 //! narrower: pin a smoke test that the default executor's
 //! `spawn` + `sleep` primitives work on tokio with reasonable
 //! precision, so a regression in either primitive (or in the trait
-//! routing through `executor.sleep` introduced in Task 10) gets
-//! caught here rather than masked by a TTL test that has many other
-//! moving parts.
+//! routing through `executor.sleep`) gets caught here rather than
+//! masked by a TTL test that has many other moving parts.
 //!
 //! `start_paused = false` so we read real wall-clock time — this is a
 //! sleep-precision check, which is meaningful only against the

--- a/sassi/tests/punnu_executor_default.rs
+++ b/sassi/tests/punnu_executor_default.rs
@@ -1,0 +1,114 @@
+//! Task 10 — `DefaultExecutor` smoke test on the tokio runtime.
+//!
+//! `PunnuExecutor` is `pub(crate)` in v0.1; this test exercises it
+//! indirectly through the public surface. The interesting end-to-end
+//! shape is "TTL sweep fires on the configured cadence" — already
+//! covered exhaustively by `punnu_ttl_sweep.rs`. This file's role is
+//! narrower: pin a smoke test that the default executor's
+//! `spawn` + `sleep` primitives work on tokio with reasonable
+//! precision, so a regression in either primitive (or in the trait
+//! routing through `executor.sleep` introduced in Task 10) gets
+//! caught here rather than masked by a TTL test that has many other
+//! moving parts.
+//!
+//! `start_paused = false` so we read real wall-clock time — this is a
+//! sleep-precision check, which is meaningful only against the
+//! actual timer, not virtual time.
+
+#![cfg(feature = "runtime-tokio")]
+
+use sassi::{Cacheable, Field, Punnu, PunnuConfig};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+        }
+    }
+}
+
+#[tokio::test]
+async fn default_executor_spawn_and_sleep_smoke() {
+    // Spin a Punnu with a short sweep interval; after one sweep
+    // tick's worth of real time, the sweep task should have been
+    // spawned and ticked at least once. We don't assert on cadence
+    // precision here (CI scheduling jitter would flake the test);
+    // we assert that *some* spawn + sleep happened by observing the
+    // sweep task's readiness signal — its presence is sufficient
+    // proof that `executor.spawn` ran the future to its first sleep.
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            ttl_sweep_interval: Some(Duration::from_millis(50)),
+            ..Default::default()
+        })
+        .build();
+
+    let notify = p
+        ._test_sweep_initialised()
+        .expect("sweep was configured; readiness signal must be present");
+
+    // The sweep should reach its first poll within a generous bound.
+    // 500ms is many orders of magnitude above scheduler latency — a
+    // failure here means `executor.spawn` did not run the future,
+    // not "CI was slow today".
+    tokio::time::timeout(Duration::from_millis(500), notify.notified())
+        .await
+        .expect("default executor failed to spawn the sweep task within 500ms");
+}
+
+#[tokio::test]
+async fn default_executor_sleep_precision_at_100ms() {
+    // Real-clock test (no `start_paused`): assert tokio's sleep is
+    // bounded above by the requested duration plus a generous slack.
+    // The slack is intentionally wide (target + 50ms) to absorb CI
+    // scheduling jitter — the goal is "regression on the order of
+    // 'sleep took 5x as long'", not chasing milliseconds.
+    //
+    // We measure `tokio::time::sleep` directly here rather than
+    // routing through `PunnuExecutor::sleep` because the trait is
+    // `pub(crate)` — the executor's sleep is the same primitive,
+    // just behind a trait. This test pins the underlying call;
+    // routing precision is verified by the TTL cadence test.
+    let target = Duration::from_millis(100);
+    let start = Instant::now();
+    tokio::time::sleep(target).await;
+    let elapsed = start.elapsed();
+
+    // Lower bound: tokio guarantees at-least the requested duration.
+    assert!(
+        elapsed >= target,
+        "sleep returned early: {:?} < target {:?}",
+        elapsed,
+        target
+    );
+
+    // Upper bound: target + 50ms. Wider than the 5% the spec
+    // motivates because CI runners occasionally pause for GC / io
+    // spikes; tighter would flake. The spec's "within 5%" is the
+    // *intent*; this test catches catastrophic regressions
+    // (sleep returned 1s late, missed the timer entirely).
+    let upper = target + Duration::from_millis(50);
+    assert!(
+        elapsed <= upper,
+        "sleep precision regression: {:?} > {:?}; the executor's sleep is leaking real time",
+        elapsed,
+        upper
+    );
+}

--- a/sassi/tests/punnu_executor_wasm.rs
+++ b/sassi/tests/punnu_executor_wasm.rs
@@ -1,0 +1,30 @@
+//! Task 10 — WASM-target executor smoke test.
+//!
+//! **Deferred to Task 18 (CI matrix expansion).** Wiring the
+//! `wasm-bindgen-test` runner needs a CI job that runs
+//! `wasm-pack test --node` (or `--headless --chrome`); both are
+//! outside the scope of Cluster B, where the runtime-decoupling work
+//! lives.
+//!
+//! The load-bearing wasm verification today is the
+//! `wasm-target` CI job in `.github/workflows/ci.yml` — it runs
+//! `cargo build -p sassi --target wasm32-unknown-unknown
+//! --no-default-features --features "serde,runtime-wasm"` so any
+//! regression in the wasm-feature build path fails CI.
+//!
+//! When wasm-bindgen-test is wired up (Task 18), this file's
+//! `#[wasm_bindgen_test]` will run a Punnu with `runtime-wasm` +
+//! TTL sweep, verifying:
+//! 1. `wasm_bindgen_futures::spawn_local` runs the sweep future.
+//! 2. `gloo_timers::future::TimeoutFuture` advances on real
+//!    browser time.
+//! 3. `web_time::Instant` reads `Performance.now()` for TTL
+//!    deadline math.
+//!
+//! For now the file exists as a placeholder (compiled out on
+//! native via the cfg gate) so the test path is reserved and
+//! discoverable.
+
+#![cfg(target_arch = "wasm32")]
+
+// Body deferred to Task 18 — see module docs for rationale.

--- a/sassi/tests/punnu_executor_wasm.rs
+++ b/sassi/tests/punnu_executor_wasm.rs
@@ -1,30 +1,29 @@
-//! Task 10 — WASM-target executor smoke test.
+//! WASM-target executor smoke test (placeholder).
 //!
-//! **Deferred to Task 18 (CI matrix expansion).** Wiring the
-//! `wasm-bindgen-test` runner needs a CI job that runs
-//! `wasm-pack test --node` (or `--headless --chrome`); both are
-//! outside the scope of Cluster B, where the runtime-decoupling work
-//! lives.
+//! Per-test wasm execution is deferred to a future
+//! `wasm-bindgen-test` integration — that needs a CI job running
+//! `wasm-pack test --node` (or `--headless --chrome`), wiring beyond
+//! the runtime-decoupling work that landed sassi's WASM target.
 //!
-//! The load-bearing wasm verification today is the
-//! `wasm-target` CI job in `.github/workflows/ci.yml` — it runs
+//! The load-bearing wasm verification today is the `wasm-target` CI
+//! job in `.github/workflows/ci.yml` — it runs
 //! `cargo build -p sassi --target wasm32-unknown-unknown
 //! --no-default-features --features "serde,runtime-wasm"` so any
 //! regression in the wasm-feature build path fails CI.
 //!
-//! When wasm-bindgen-test is wired up (Task 18), this file's
+//! When wasm-bindgen-test gets wired up, this file's
 //! `#[wasm_bindgen_test]` will run a Punnu with `runtime-wasm` +
 //! TTL sweep, verifying:
 //! 1. `wasm_bindgen_futures::spawn_local` runs the sweep future.
-//! 2. `gloo_timers::future::TimeoutFuture` advances on real
-//!    browser time.
-//! 3. `web_time::Instant` reads `Performance.now()` for TTL
-//!    deadline math.
+//! 2. `gloo_timers::future::TimeoutFuture` advances on real browser
+//!    time.
+//! 3. `web_time::Instant` reads `Performance.now()` for TTL deadline
+//!    math.
 //!
-//! For now the file exists as a placeholder (compiled out on
-//! native via the cfg gate) so the test path is reserved and
-//! discoverable.
+//! For now the file exists as a placeholder (compiled out on native
+//! via the cfg gate) so the test path is reserved and discoverable.
 
 #![cfg(target_arch = "wasm32")]
 
-// Body deferred to Task 18 — see module docs for rationale.
+// Body deferred to the wasm-bindgen-test integration — see module
+// docs for rationale.

--- a/sassi/tests/punnu_get_or_fetch.rs
+++ b/sassi/tests/punnu_get_or_fetch.rs
@@ -1,0 +1,168 @@
+//! Task 7 — `Punnu::get_or_fetch` happy path + miss + error variants.
+//!
+//! Spec §3.5 describes the lazy-fetch-on-miss pattern: on L1 hit,
+//! the fetcher is not invoked; on miss, the fetcher's `Some(value)`
+//! lands in L1 (so a subsequent `get` is a hit) and `None` propagates
+//! without caching. The single-flight cancellation contract lives in
+//! `punnu_single_flight.rs`; this file pins the non-coalescing
+//! semantics.
+
+#![cfg(feature = "runtime-tokio")]
+
+use sassi::{Cacheable, FetchError, Field, Punnu};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+    name: String,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+        }
+    }
+}
+
+#[tokio::test]
+async fn fetcher_called_on_miss_value_cached() {
+    let p = Punnu::<E>::builder().build();
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    let counter_for_fetch = counter.clone();
+    let result = p
+        .get_or_fetch(&1, move |id| {
+            let counter = counter_for_fetch.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, FetchError>(Some(E {
+                    id,
+                    name: "fetched".into(),
+                }))
+            }
+        })
+        .await
+        .unwrap();
+
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().name, "fetched");
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    // Subsequent get is an L1 hit — fetcher not called again.
+    let cached = p.get(&1);
+    assert!(cached.is_some());
+    assert_eq!(cached.unwrap().name, "fetched");
+
+    // get_or_fetch on the cached id also doesn't re-invoke.
+    let cached_again = p
+        .get_or_fetch(&1, |_| async {
+            panic!("fetcher must not run for cached id");
+        })
+        .await
+        .unwrap();
+    assert!(cached_again.is_some());
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn fetcher_returning_none_caches_nothing() {
+    let p = Punnu::<E>::builder().build();
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    let counter_for_fetch = counter.clone();
+    let result = p
+        .get_or_fetch(&999, move |_id| {
+            let counter = counter_for_fetch.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, FetchError>(None)
+            }
+        })
+        .await
+        .unwrap();
+
+    assert!(result.is_none());
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    // Cache stays empty — None doesn't get stored.
+    assert!(p.get(&999).is_none());
+    assert_eq!(p.len(), 0);
+
+    // A second call retries (no negative-cache; that's a future-task
+    // enhancement if needed).
+    let counter_for_second = counter.clone();
+    let _ = p
+        .get_or_fetch(&999, move |_id| {
+            let counter = counter_for_second.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, FetchError>(None)
+            }
+        })
+        .await
+        .unwrap();
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn fetcher_error_propagates() {
+    let p = Punnu::<E>::builder().build();
+
+    let result = p
+        .get_or_fetch(&1, |_id| async {
+            Err::<Option<E>, _>(FetchError::Serialization("simulated failure".into()))
+        })
+        .await;
+
+    match result {
+        Err(FetchError::Serialization(msg)) => {
+            assert_eq!(msg, "simulated failure");
+        }
+        other => panic!("expected Serialization error, got {other:?}"),
+    }
+
+    // Cache untouched on error.
+    assert!(p.get(&1).is_none());
+    assert_eq!(p.len(), 0);
+}
+
+#[tokio::test]
+async fn fetcher_custom_error_propagates() {
+    let p = Punnu::<E>::builder().build();
+
+    #[derive(Debug)]
+    struct MyErr(&'static str);
+    impl std::fmt::Display for MyErr {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+    impl std::error::Error for MyErr {}
+
+    let result = p
+        .get_or_fetch(&1, |_id| async {
+            Err::<Option<E>, _>(FetchError::Custom(Box::new(MyErr("custom failure"))))
+        })
+        .await;
+
+    match result {
+        Err(FetchError::Custom(e)) => {
+            assert_eq!(format!("{e}"), "custom failure");
+        }
+        other => panic!("expected Custom error, got {other:?}"),
+    }
+}

--- a/sassi/tests/punnu_get_or_fetch.rs
+++ b/sassi/tests/punnu_get_or_fetch.rs
@@ -1,4 +1,4 @@
-//! Task 7 — `Punnu::get_or_fetch` happy path + miss + error variants.
+//! `Punnu::get_or_fetch` happy path + miss + error variants.
 //!
 //! Spec §3.5 describes the lazy-fetch-on-miss pattern: on L1 hit,
 //! the fetcher is not invoked; on miss, the fetcher's `Some(value)`

--- a/sassi/tests/punnu_get_or_fetch_many.rs
+++ b/sassi/tests/punnu_get_or_fetch_many.rs
@@ -1,4 +1,4 @@
-//! Task 7 — `Punnu::get_or_fetch_many` batch path.
+//! `Punnu::get_or_fetch_many` batch path.
 //!
 //! Spec §3.5: split ids into hits + misses, send one batch fetch
 //! for the missing set, merge with hits. Per-id single-flight on

--- a/sassi/tests/punnu_get_or_fetch_many.rs
+++ b/sassi/tests/punnu_get_or_fetch_many.rs
@@ -1,0 +1,162 @@
+//! Task 7 — `Punnu::get_or_fetch_many` batch path.
+//!
+//! Spec §3.5: split ids into hits + misses, send one batch fetch
+//! for the missing set, merge with hits. Per-id single-flight on
+//! individual lookups within the batch.
+
+#![cfg(feature = "runtime-tokio")]
+
+use sassi::{Cacheable, FetchError, Field, Punnu};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+        }
+    }
+}
+
+#[tokio::test]
+async fn batch_only_fetches_missing() {
+    let p = Punnu::<E>::builder().build();
+
+    // Pre-cache id 1 and 3.
+    p.insert(E { id: 1 }).await.unwrap();
+    p.insert(E { id: 3 }).await.unwrap();
+
+    let received: Arc<std::sync::Mutex<Vec<i64>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let received_for_fetcher = received.clone();
+    let result = p
+        .get_or_fetch_many(&[1, 2, 3, 4], move |missing| {
+            let received = received_for_fetcher.clone();
+            async move {
+                received.lock().unwrap().extend(missing.iter().copied());
+                Ok::<_, FetchError>(missing.into_iter().map(|id| E { id }).collect())
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 4, "all four ids resolved");
+
+    // Fetcher saw only the missing ids — 2 and 4.
+    let mut got = received.lock().unwrap().clone();
+    got.sort();
+    assert_eq!(got, vec![2, 4]);
+
+    // Both newly-fetched ids landed in L1.
+    assert!(p.get(&2).is_some());
+    assert!(p.get(&4).is_some());
+    assert_eq!(p.len(), 4);
+}
+
+#[tokio::test]
+async fn empty_missing_returns_only_hits() {
+    let p = Punnu::<E>::builder().build();
+    p.insert(E { id: 1 }).await.unwrap();
+    p.insert(E { id: 2 }).await.unwrap();
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter_for_fetch = counter.clone();
+
+    let result = p
+        .get_or_fetch_many(&[1, 2], move |_missing| {
+            let counter = counter_for_fetch.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, FetchError>(Vec::new())
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "fetcher must not run when nothing is missing"
+    );
+}
+
+#[tokio::test]
+async fn duplicates_in_input_dedupe_before_fetcher() {
+    // Consumers may pass `&[1, 1, 1]`; the batch fetcher should see
+    // a deduplicated list (`vec![1]`), and the result should still
+    // contain three Arc handles (one per requested id, all pointing
+    // to the same value).
+    let p = Punnu::<E>::builder().build();
+    let received: Arc<std::sync::Mutex<Vec<i64>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let received_for_fetcher = received.clone();
+
+    let result = p
+        .get_or_fetch_many(&[1, 1, 1], move |missing| {
+            let received = received_for_fetcher.clone();
+            async move {
+                received.lock().unwrap().extend(missing.iter().copied());
+                Ok::<_, FetchError>(missing.into_iter().map(|id| E { id }).collect())
+            }
+        })
+        .await
+        .unwrap();
+
+    // The fetcher saw only one distinct id.
+    let got = received.lock().unwrap().clone();
+    assert_eq!(got, vec![1]);
+    // The result is non-empty (at least the fetched arc).
+    assert!(!result.is_empty());
+    // L1 has exactly one entry.
+    assert_eq!(p.len(), 1);
+}
+
+#[tokio::test]
+async fn batch_fetcher_error_propagates() {
+    let p = Punnu::<E>::builder().build();
+
+    let result = p
+        .get_or_fetch_many(&[1, 2], |_missing| async {
+            Err::<Vec<E>, _>(FetchError::Serialization("batch failed".into()))
+        })
+        .await;
+
+    assert!(matches!(result, Err(FetchError::Serialization(_))));
+    assert_eq!(p.len(), 0);
+}
+
+#[tokio::test]
+async fn empty_input_returns_empty_without_fetcher() {
+    let p = Punnu::<E>::builder().build();
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter_for_fetch = counter.clone();
+
+    let result = p
+        .get_or_fetch_many(&[], move |_missing| {
+            let counter = counter_for_fetch.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, FetchError>(Vec::new())
+            }
+        })
+        .await
+        .unwrap();
+
+    assert!(result.is_empty());
+    assert_eq!(counter.load(Ordering::SeqCst), 0);
+}

--- a/sassi/tests/punnu_identity_map.rs
+++ b/sassi/tests/punnu_identity_map.rs
@@ -1,4 +1,4 @@
-//! Task 4 — `Punnu<T>` identity-map basics: insert, get, invalidate,
+//! `Punnu<T>` identity-map basics: insert, get, invalidate,
 //! LRU eviction.
 //!
 //! Each test hand-writes the [`sassi::Cacheable`] impl rather than

--- a/sassi/tests/punnu_metrics.rs
+++ b/sassi/tests/punnu_metrics.rs
@@ -1,4 +1,4 @@
-//! Task 8 — `PunnuMetrics` observability hook.
+//! `PunnuMetrics` observability hook.
 //!
 //! Spec §3.5.1 — sassi commits to firing `record_*` callbacks on every
 //! event of interest; consumers wire to whatever metrics layer they

--- a/sassi/tests/punnu_metrics.rs
+++ b/sassi/tests/punnu_metrics.rs
@@ -1,0 +1,265 @@
+//! Task 8 — `PunnuMetrics` observability hook.
+//!
+//! Spec §3.5.1 — sassi commits to firing `record_*` callbacks on every
+//! event of interest; consumers wire to whatever metrics layer they
+//! already use. This file pins the call sites so a regression in any
+//! one of them surfaces immediately rather than waiting for a
+//! production dashboard to go silent.
+//!
+//! Coverage:
+//! - `record_hit` on `get` cache hit (CacheTier::L1).
+//! - `record_miss` on `get` miss + on TTL-expired get.
+//! - `record_eviction` on manual `invalidate`, on LRU pressure, on
+//!   TTL expiry (lazy + sweep paths).
+//! - `record_lru_size` after every insert / invalidate.
+//! - `record_fetch_latency` after every `get_or_fetch` slow-path.
+//! - No calls when `metrics: None`.
+
+#![cfg(feature = "runtime-tokio")]
+
+use sassi::{
+    BackendError, CacheTier, Cacheable, EventReason, FetchError, Field, InvalidationReason, Punnu,
+    PunnuConfig, PunnuMetrics,
+};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+        }
+    }
+}
+
+#[derive(Default)]
+struct CountingMetrics {
+    hits: Mutex<Vec<(String, CacheTier)>>,
+    misses: Mutex<Vec<String>>,
+    evictions: Mutex<Vec<(String, EventReason)>>,
+    lru_sizes: Mutex<Vec<(String, usize)>>,
+    fetch_latencies: Mutex<Vec<(String, Duration)>>,
+    backend_errors: Mutex<Vec<String>>,
+}
+
+impl PunnuMetrics for CountingMetrics {
+    fn record_hit(&self, type_name: &'static str, tier: CacheTier) {
+        self.hits.lock().unwrap().push((type_name.into(), tier));
+    }
+    fn record_miss(&self, type_name: &'static str) {
+        self.misses.lock().unwrap().push(type_name.into());
+    }
+    fn record_eviction(&self, type_name: &'static str, reason: EventReason) {
+        self.evictions
+            .lock()
+            .unwrap()
+            .push((type_name.into(), reason));
+    }
+    fn record_backend_error(&self, _type_name: &'static str, err: &BackendError) {
+        self.backend_errors.lock().unwrap().push(format!("{err}"));
+    }
+    fn record_fetch_latency(&self, type_name: &'static str, duration: Duration) {
+        self.fetch_latencies
+            .lock()
+            .unwrap()
+            .push((type_name.into(), duration));
+    }
+    fn record_lru_size(&self, type_name: &'static str, size: usize) {
+        self.lru_sizes
+            .lock()
+            .unwrap()
+            .push((type_name.into(), size));
+    }
+}
+
+fn punnu_with_metrics(metrics: Arc<CountingMetrics>) -> Punnu<E> {
+    let dyn_metrics: Arc<dyn PunnuMetrics> = metrics;
+    Punnu::<E>::builder()
+        .config(PunnuConfig {
+            metrics: Some(dyn_metrics),
+            ..Default::default()
+        })
+        .build()
+}
+
+#[tokio::test]
+async fn metrics_records_hit_and_miss() {
+    let m = Arc::new(CountingMetrics::default());
+    let p = punnu_with_metrics(m.clone());
+
+    p.insert(E { id: 1 }).await.unwrap();
+    let _ = p.get(&1); // hit
+    let _ = p.get(&999); // miss
+
+    let hits = m.hits.lock().unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].1, CacheTier::L1);
+    assert!(
+        hits[0].0.contains("E"),
+        "type_name should include type identity; got {}",
+        hits[0].0
+    );
+
+    let misses = m.misses.lock().unwrap();
+    assert_eq!(misses.len(), 1);
+}
+
+#[tokio::test]
+async fn metrics_records_lru_size_after_insert_and_invalidate() {
+    let m = Arc::new(CountingMetrics::default());
+    let p = punnu_with_metrics(m.clone());
+
+    p.insert(E { id: 1 }).await.unwrap();
+    p.insert(E { id: 2 }).await.unwrap();
+    p.invalidate(&1, InvalidationReason::Manual).await;
+
+    let sizes = m.lru_sizes.lock().unwrap().clone();
+    assert!(
+        sizes.len() >= 3,
+        "expected ≥3 lru_size samples, got {sizes:?}"
+    );
+    // After two inserts and one invalidate, the last sample should
+    // show 1 (only id=2 left). The sequence is: insert 1 → size=1,
+    // insert 2 → size=2, invalidate 1 → size=1.
+    assert_eq!(sizes[0].1, 1);
+    assert_eq!(sizes[1].1, 2);
+    assert_eq!(sizes[2].1, 1);
+}
+
+#[tokio::test]
+async fn metrics_records_eviction_on_manual_invalidate() {
+    let m = Arc::new(CountingMetrics::default());
+    let p = punnu_with_metrics(m.clone());
+
+    p.insert(E { id: 1 }).await.unwrap();
+    p.invalidate(&1, InvalidationReason::Manual).await;
+
+    let evictions = m.evictions.lock().unwrap().clone();
+    assert_eq!(evictions.len(), 1);
+    assert_eq!(evictions[0].1, EventReason::Manual);
+}
+
+#[tokio::test]
+async fn metrics_records_eviction_on_lru_pressure() {
+    let m = Arc::new(CountingMetrics::default());
+    let dyn_metrics: Arc<dyn PunnuMetrics> = m.clone();
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            lru_size: 2,
+            metrics: Some(dyn_metrics),
+            ..Default::default()
+        })
+        .build();
+
+    p.insert(E { id: 1 }).await.unwrap();
+    p.insert(E { id: 2 }).await.unwrap();
+    // Inserting a third entry evicts id=1 under default LRU pressure.
+    p.insert(E { id: 3 }).await.unwrap();
+
+    let evictions = m.evictions.lock().unwrap().clone();
+    assert!(
+        evictions
+            .iter()
+            .any(|(_, r)| matches!(r, EventReason::LruEvict { .. })),
+        "expected an LruEvict eviction, got {evictions:?}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn metrics_records_eviction_on_lazy_ttl_expiry() {
+    let m = Arc::new(CountingMetrics::default());
+    let dyn_metrics: Arc<dyn PunnuMetrics> = m.clone();
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            default_ttl: Some(Duration::from_secs(5)),
+            metrics: Some(dyn_metrics),
+            ..Default::default()
+        })
+        .build();
+
+    p.insert(E { id: 1 }).await.unwrap();
+    tokio::time::advance(Duration::from_secs(10)).await;
+    let _ = p.get(&1); // triggers lazy TTL expiry
+
+    let evictions = m.evictions.lock().unwrap().clone();
+    assert!(
+        evictions
+            .iter()
+            .any(|(_, r)| matches!(r, EventReason::TtlExpired { .. })),
+        "expected a TtlExpired eviction, got {evictions:?}"
+    );
+}
+
+#[tokio::test]
+async fn metrics_records_fetch_latency_on_slow_path() {
+    let m = Arc::new(CountingMetrics::default());
+    let p = punnu_with_metrics(m.clone());
+
+    let _ = p
+        .get_or_fetch(&1, |id| async move { Ok::<_, FetchError>(Some(E { id })) })
+        .await
+        .unwrap();
+
+    let latencies = m.fetch_latencies.lock().unwrap().clone();
+    assert_eq!(
+        latencies.len(),
+        1,
+        "expected one fetch_latency sample, got {latencies:?}"
+    );
+}
+
+#[tokio::test]
+async fn metrics_no_fetch_latency_on_l1_hit_path() {
+    let m = Arc::new(CountingMetrics::default());
+    let p = punnu_with_metrics(m.clone());
+
+    p.insert(E { id: 1 }).await.unwrap();
+    // get_or_fetch on cached id → L1 hit, no slow-path; no
+    // fetch_latency sample.
+    let _ = p
+        .get_or_fetch(&1, |_| async {
+            panic!("fetcher must not run for cached id");
+        })
+        .await
+        .unwrap();
+
+    let latencies = m.fetch_latencies.lock().unwrap().clone();
+    assert_eq!(latencies.len(), 0);
+}
+
+#[tokio::test]
+async fn metrics_none_means_no_calls() {
+    // When `metrics: None`, the no-op path must compile to a single
+    // null-check at every call site — no panics, no overhead. This
+    // test is the regression fence.
+    let p = Punnu::<E>::builder().build(); // default metrics: None
+
+    p.insert(E { id: 1 }).await.unwrap();
+    let _ = p.get(&1);
+    let _ = p.get(&999);
+    p.invalidate(&1, InvalidationReason::Manual).await;
+    let _ = p
+        .get_or_fetch(&2, |id| async move { Ok::<_, FetchError>(Some(E { id })) })
+        .await;
+
+    // No assertion needed — the test passes if no panics fire and
+    // the compiler accepts the code. Sanity: post-invalidate, len is
+    // 1 (the get_or_fetch above inserted id=2).
+    assert_eq!(p.len(), 1);
+}

--- a/sassi/tests/punnu_namespace.rs
+++ b/sassi/tests/punnu_namespace.rs
@@ -1,0 +1,95 @@
+//! Task 8 — `PunnuConfig::namespace` plumbing + validation.
+//!
+//! Spec §3.5: namespace governs L2 backend cache-key prefixes.
+//! L1 storage is per-Punnu-instance and unaffected by namespace —
+//! this file verifies the config plumbs through cleanly without
+//! accidentally affecting L1 semantics, and that builder-time
+//! validation rejects degenerate values (empty string).
+//!
+//! The L2-side namespace effect (Redis backend key prefixing) is
+//! exercised by the redis backend tests in Cluster D, Task 13.
+
+#![cfg(feature = "runtime-tokio")]
+
+use sassi::{Cacheable, Field, Punnu, PunnuConfig};
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+        }
+    }
+}
+
+#[tokio::test]
+async fn namespace_does_not_affect_l1() {
+    // L1 storage is per-Punnu-instance; namespace governs only L2
+    // backend keys. Two Punnus with different namespaces against
+    // (conceptually) the same backend never collide on L1 because
+    // L1 is per-instance anyway.
+    let p1 = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            namespace: Some("env_a".into()),
+            ..Default::default()
+        })
+        .build();
+    let p2 = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            namespace: Some("env_b".into()),
+            ..Default::default()
+        })
+        .build();
+
+    p1.insert(E { id: 1 }).await.unwrap();
+    p2.insert(E { id: 1 }).await.unwrap();
+
+    assert_eq!(p1.len(), 1);
+    assert_eq!(p2.len(), 1);
+}
+
+#[tokio::test]
+async fn namespace_value_round_trips_through_config_accessor() {
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            namespace: Some("staging_v1".into()),
+            ..Default::default()
+        })
+        .build();
+    assert_eq!(p.config().namespace.as_deref(), Some("staging_v1"));
+}
+
+#[tokio::test]
+async fn namespace_none_round_trips_through_config_accessor() {
+    let p = Punnu::<E>::builder().build();
+    assert_eq!(p.config().namespace, None);
+}
+
+#[test]
+#[should_panic(expected = "PunnuConfig::namespace must be non-empty when set")]
+fn empty_namespace_string_is_rejected_at_build() {
+    // Degenerate config: empty-string namespace would silently
+    // prefix L2 keys with a leading separator and could collide
+    // with un-namespaced deployments. Builder-time guard.
+    let _: Punnu<E> = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            namespace: Some(String::new()),
+            ..Default::default()
+        })
+        .build();
+}

--- a/sassi/tests/punnu_namespace.rs
+++ b/sassi/tests/punnu_namespace.rs
@@ -1,4 +1,4 @@
-//! Task 8 — `PunnuConfig::namespace` plumbing + validation.
+//! `PunnuConfig::namespace` plumbing + validation.
 //!
 //! Spec §3.5: namespace governs L2 backend cache-key prefixes.
 //! L1 storage is per-Punnu-instance and unaffected by namespace —
@@ -6,8 +6,9 @@
 //! accidentally affecting L1 semantics, and that builder-time
 //! validation rejects degenerate values (empty string).
 //!
-//! The L2-side namespace effect (Redis backend key prefixing) is
-//! exercised by the redis backend tests in Cluster D, Task 13.
+//! The L2-side namespace effect (Redis backend key prefixing) will
+//! be exercised by the future redis backend integration tests; this
+//! file pins the L1 contract today.
 
 #![cfg(feature = "runtime-tokio")]
 

--- a/sassi/tests/punnu_single_flight.rs
+++ b/sassi/tests/punnu_single_flight.rs
@@ -1,0 +1,282 @@
+//! Task 7 — single-flight cancellation contract (spec §3.5.1).
+//!
+//! Four owner-loss cases must all behave deterministically:
+//!
+//! 1. Originator dropped, peers polling — fetch stays alive.
+//! 2. All awaiters drop — fetch is cancelled, registry slot cleared,
+//!    next call retries from cold.
+//! 3. Fetcher panics — every awaiter sees `FetcherPanic`.
+//! 4. Caller-imposed deadline — composes with `tokio::time::timeout`;
+//!    surfaces as case 1 from the registry's perspective.
+//!
+//! Cases 1, 2, 3 have direct tests here. Case 4 is exercised via the
+//! `cancellation_with_peers_keeps_fetch_alive` test (the originator
+//! has a short timeout; the peer has a long one).
+
+#![cfg(feature = "runtime-tokio")]
+
+use sassi::{Cacheable, FetchError, Field, Punnu};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+struct E {
+    id: i64,
+    name: String,
+}
+
+#[derive(Default)]
+struct EFields {
+    #[allow(dead_code)]
+    id: Field<E, i64>,
+}
+
+impl Cacheable for E {
+    type Id = i64;
+    type Fields = EFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+    fn fields() -> EFields {
+        EFields {
+            id: Field::new("id", |e| &e.id),
+        }
+    }
+}
+
+#[tokio::test]
+async fn n_concurrent_get_or_fetch_calls_invoke_fetcher_once() {
+    let p = Punnu::<E>::builder().build();
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    // Spawn 10 racing calls for the same id. Counter increments
+    // inside the fetcher; we assert it ends at exactly 1.
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let p = p.clone();
+        let counter = counter.clone();
+        handles.push(tokio::spawn(async move {
+            p.get_or_fetch(&1, move |id| {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    // Hold the fetch open long enough for all peers
+                    // to register before the resolution lands.
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    Ok::<_, FetchError>(Some(E {
+                        id,
+                        name: "fetched".into(),
+                    }))
+                }
+            })
+            .await
+        }));
+    }
+
+    for h in handles {
+        let result = h.await.unwrap().unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "fetched");
+    }
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "fetcher should be called exactly once across coalesced peers"
+    );
+
+    // Result is now in L1 — subsequent calls hit cache, fetcher
+    // unchanged.
+    let cached = p.get(&1);
+    assert!(cached.is_some());
+    assert_eq!(cached.unwrap().name, "fetched");
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn cancellation_with_peers_keeps_fetch_alive() {
+    // Case 1 from the cancellation contract: the originator times
+    // out via `tokio::time::timeout`, but a peer is still polling
+    // and gets the result. The fetcher should run exactly once.
+    let p = Punnu::<E>::builder().build();
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    let p1 = p.clone();
+    let c1 = counter.clone();
+    let originator = tokio::spawn(async move {
+        // Short timeout — the fetcher takes 100ms, the timeout fires
+        // at 20ms. The originator drops its future.
+        let _ = tokio::time::timeout(
+            Duration::from_millis(20),
+            p1.get_or_fetch(&1, move |id| {
+                let c1 = c1.clone();
+                async move {
+                    c1.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    Ok::<_, FetchError>(Some(E {
+                        id,
+                        name: "kept-alive".into(),
+                    }))
+                }
+            }),
+        )
+        .await;
+    });
+
+    // Give the originator a moment to register its fetch with the
+    // single-flight registry before the peer arrives.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let p2 = p.clone();
+    let peer = tokio::spawn(async move {
+        // Peer attaches to the same in-flight fetch. Its own fetcher
+        // closure must NOT run — coalescing should hand it the
+        // existing future.
+        p2.get_or_fetch(&1, |_| async {
+            panic!("peer's fetcher should not be invoked");
+        })
+        .await
+    });
+
+    let _ = originator.await;
+    let result = peer.await.unwrap().unwrap();
+    assert!(
+        result.is_some(),
+        "peer should still see the cached value even after originator timed out"
+    );
+    assert_eq!(result.unwrap().name, "kept-alive");
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "fetcher invoked exactly once across the coalesced peers"
+    );
+}
+
+#[tokio::test]
+async fn all_awaiters_dropped_clears_registry_and_next_call_retries_from_cold() {
+    // Case 2: every awaiter drops before the fetch resolves; the
+    // registry slot is cleared (via the SlotGuard inside the future),
+    // and a subsequent call invokes the fetcher fresh.
+    let p = Punnu::<E>::builder().build();
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    let p1 = p.clone();
+    let c1 = counter.clone();
+    // Originator with a short timeout. No peer.
+    let originator = tokio::spawn(async move {
+        let _ = tokio::time::timeout(
+            Duration::from_millis(20),
+            p1.get_or_fetch(&1, move |id| {
+                let c1 = c1.clone();
+                async move {
+                    c1.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    Ok::<_, FetchError>(Some(E {
+                        id,
+                        name: "first".into(),
+                    }))
+                }
+            }),
+        )
+        .await;
+    });
+
+    // Wait for the originator to drop the future via timeout.
+    let _ = originator.await;
+
+    // After all awaiters dropped, the registry slot should be empty.
+    // A fresh get_or_fetch must invoke the fetcher again.
+    let counter_for_second = counter.clone();
+    let result = p
+        .get_or_fetch(&1, move |id| {
+            let c = counter_for_second.clone();
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, FetchError>(Some(E {
+                    id,
+                    name: "second".into(),
+                }))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.name, "second");
+    // Counter is at least 2 (the second call's fetcher ran). The
+    // first call's fetcher may or may not have completed before its
+    // future was dropped — the contract says "not your problem"; what
+    // matters is that the second call retried from cold.
+    assert!(counter.load(Ordering::SeqCst) >= 2);
+}
+
+#[tokio::test]
+async fn fetcher_panic_propagates_as_fetcher_panic_error() {
+    // Case 3: fetcher panics; every awaiter sees `FetcherPanic`.
+    let p = Punnu::<E>::builder().build();
+
+    let result = p
+        .get_or_fetch(&1, |_| async {
+            panic!("simulated fetcher panic");
+            #[allow(unreachable_code)]
+            Ok::<Option<E>, FetchError>(None)
+        })
+        .await;
+
+    match result {
+        Err(FetchError::FetcherPanic { type_name, message }) => {
+            assert!(
+                type_name.contains("E"),
+                "type_name should include the cached type's name; got {type_name}"
+            );
+            assert_eq!(message, "simulated fetcher panic");
+        }
+        other => panic!("expected FetcherPanic, got {other:?}"),
+    }
+
+    // After a panic, the registry slot is cleared and a subsequent
+    // call retries.
+    let result = p
+        .get_or_fetch(&1, |id| async move {
+            Ok::<_, FetchError>(Some(E {
+                id,
+                name: "after-panic".into(),
+            }))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.name, "after-panic");
+}
+
+#[tokio::test]
+async fn fetcher_panic_broadcasts_to_all_concurrent_peers() {
+    // Multiple peers racing for the same id when the fetcher panics
+    // — every peer must see `FetcherPanic`, not a hang or a stale
+    // value.
+    let p = Punnu::<E>::builder().build();
+
+    let mut handles = Vec::new();
+    for _ in 0..5 {
+        let p = p.clone();
+        handles.push(tokio::spawn(async move {
+            p.get_or_fetch(&1, |_id| async {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                panic!("broadcast panic");
+                #[allow(unreachable_code)]
+                Ok::<Option<E>, FetchError>(None)
+            })
+            .await
+        }));
+    }
+
+    for h in handles {
+        match h.await.unwrap() {
+            Err(FetchError::FetcherPanic { message, .. }) => {
+                assert_eq!(message, "broadcast panic");
+            }
+            other => panic!("expected FetcherPanic on every peer, got {other:?}"),
+        }
+    }
+}

--- a/sassi/tests/punnu_single_flight.rs
+++ b/sassi/tests/punnu_single_flight.rs
@@ -1,4 +1,4 @@
-//! Task 7 — single-flight cancellation contract (spec §3.5.1).
+//! single-flight cancellation contract (spec §3.5.1).
 //!
 //! Four owner-loss cases must all behave deterministically:
 //!
@@ -360,4 +360,75 @@ async fn coalesced_awaiters_fire_insert_event_exactly_once() {
     // direct hit (no fetcher invocation, no further events).
     let cached = p.get(&1).expect("entry cached after fetch");
     assert_eq!(cached.name, "fetched");
+}
+
+/// Proof of the BLOCK-M2 fix: expired-conflict during a fetch must
+/// not leave the cache empty.
+///
+/// Pre-fix scenario: with `OnConflict::Reject`, an existing entry's
+/// TTL elapses during a `get_or_fetch`. The on_fetched closure
+/// called `insert_arc_into_l1` which saw the still-present (expired
+/// but not yet popped) entry and returned `Conflict`. The fall-back
+/// `punnu.get(&id)` then ran the lazy-expiry path, popped the
+/// expired entry, and returned `None`. `unwrap_or(arc)` returned the
+/// freshly-fetched value to the caller — but it was never inserted.
+/// Subsequent `get(&id)` calls would miss, violating
+/// `get_or_fetch`'s documented post-condition.
+///
+/// The fix (`insert_arc_or_existing`) treats expired entries as
+/// absent and inserts the freshly-fetched value atomically under
+/// one L1 lock. `OnConflict::Reject` does not apply on this path.
+#[tokio::test(start_paused = true)]
+async fn expired_existing_entry_does_not_block_single_flight_insert() {
+    use sassi::{OnConflict, PunnuConfig};
+
+    let p = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            on_conflict: OnConflict::Reject,
+            default_ttl: Some(Duration::from_secs(1)),
+            ..Default::default()
+        })
+        .build();
+
+    // Original entry with 1s TTL.
+    p.insert(E {
+        id: 1,
+        name: "original".into(),
+    })
+    .await
+    .unwrap();
+
+    // Advance past the TTL — the entry is expired but not yet
+    // lazily popped (no `get` has been called).
+    tokio::time::advance(Duration::from_secs(2)).await;
+
+    // Trigger a get_or_fetch. The fetcher returns Some(new_value).
+    // Pre-fix: on_fetched hits Conflict because the expired entry
+    // is still in the LRU map; lazy `get` pops it; `unwrap_or(arc)`
+    // returns the never-inserted fresh value. Post-fix:
+    // insert_arc_or_existing treats the expired entry as absent and
+    // inserts the fresh value atomically.
+    let result = p
+        .get_or_fetch(&1, |id| async move {
+            Ok::<_, FetchError>(Some(E {
+                id,
+                name: "fresh".into(),
+            }))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        result.name, "fresh",
+        "get_or_fetch returns the freshly-fetched value to the caller"
+    );
+
+    // Headline assertion: the freshly-fetched value is in L1.
+    // Subsequent get must hit, not miss. Pre-fix, it would miss
+    // (the value was never inserted under the Conflict-then-get path).
+    let cached = p
+        .get(&1)
+        .expect("subsequent get must hit; pre-fix it would miss");
+    assert_eq!(cached.name, "fresh");
 }

--- a/sassi/tests/punnu_single_flight.rs
+++ b/sassi/tests/punnu_single_flight.rs
@@ -280,3 +280,84 @@ async fn fetcher_panic_broadcasts_to_all_concurrent_peers() {
         }
     }
 }
+
+/// Proof of the BLOCK-M1 fix: the L1 insert (and its `PunnuEvent::Insert`
+/// emission, TTL deadline construction, and `OnConflict` policy
+/// evaluation) must fire **exactly once** per fetch — not once per
+/// coalesced peer.
+///
+/// Before this fix, every awaiter ran `Punnu::insert_arc_into_l1`
+/// after the shared future resolved, so 5 coalesced peers fired 5
+/// Insert events for one fetched value. Worse, with
+/// `OnConflict::Reject`, peers 2..5 would have seen `Conflict`
+/// despite a successful shared fetch.
+///
+/// The fix moves the insert *inside* the shared future body via the
+/// `on_fetched` callback. Coalesced peers receive the canonical
+/// `Arc<T>` from the same Shared output without re-running the
+/// insert.
+#[tokio::test]
+async fn coalesced_awaiters_fire_insert_event_exactly_once() {
+    use sassi::PunnuEvent;
+
+    let p = Punnu::<E>::builder().build();
+    let mut events = p.events();
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::with_capacity(5);
+    for _ in 0..5 {
+        let p_clone = p.clone();
+        let counter = counter.clone();
+        handles.push(tokio::spawn(async move {
+            p_clone
+                .get_or_fetch(&1, move |id| {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        // Sleep so the peers have time to attach.
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        Ok::<_, FetchError>(Some(E {
+                            id,
+                            name: "fetched".into(),
+                        }))
+                    }
+                })
+                .await
+        }));
+    }
+
+    for h in handles {
+        let result = h.await.unwrap().unwrap();
+        assert!(result.is_some(), "all peers see the canonical value");
+    }
+
+    // Fetcher invoked exactly once (single-flight) — already covered by
+    // `n_concurrent_get_or_fetch_calls_invoke_fetcher_once` above; we
+    // assert it again here for clarity.
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "fetcher invoked exactly once across coalesced peers"
+    );
+
+    // The headline assertion: exactly one Insert event for id=1.
+    // Without the M1 fix, this would fire 5 times.
+    let mut insert_count = 0;
+    while let Ok(ev) = events.try_recv() {
+        if let PunnuEvent::Insert { value } = ev
+            && value.id == 1
+        {
+            insert_count += 1;
+        }
+    }
+    assert_eq!(
+        insert_count, 1,
+        "5 coalesced get_or_fetch calls must fire exactly one Insert event \
+         (not one per peer); proof of BLOCK-M1 fix"
+    );
+
+    // After the fetch, the cache has the value — subsequent get is a
+    // direct hit (no fetcher invocation, no further events).
+    let cached = p.get(&1).expect("entry cached after fetch");
+    assert_eq!(cached.name, "fetched");
+}

--- a/sassi/tests/punnu_single_flight.rs
+++ b/sassi/tests/punnu_single_flight.rs
@@ -414,14 +414,31 @@ async fn expired_concurrent_insert_does_not_block_single_flight_insert() {
     // Step 2: Actor A starts get_or_fetch with a fetcher that awaits
     // a Notify. Cache is empty → initial get(1) misses → registers
     // in-flight fetch → fetcher runs → fetcher parks on Notify.
+    //
+    // The fetcher fires `fetcher_started_tx` *before* awaiting `go`,
+    // giving the test a deterministic readiness signal: by the time
+    // the test sees the oneshot resolve, Actor A has definitely (a)
+    // called the initial `self.get(id)` (cache miss), (b) registered
+    // the single-flight entry, and (c) entered the fetcher body.
+    // Actor A is parked on `go.notified()`. Without this, a
+    // `yield_now()` heuristic could let Actor B's insert beat Actor
+    // A's initial `get`, and Actor A's later `get` would lazy-pop
+    // the expired B entry before on_fetched ran — making the test
+    // vacuous against pre-fix code. Same shape as the issue #4
+    // sweep handshake: deterministic readiness > yield count.
     let go = Arc::new(Notify::new());
     let go_for_fetch = go.clone();
     let p_for_fetch = p.clone();
+    let (fetcher_started_tx, fetcher_started_rx) = tokio::sync::oneshot::channel::<()>();
     let actor_a = tokio::spawn(async move {
         p_for_fetch
             .get_or_fetch(&1, move |id| {
                 let go = go_for_fetch.clone();
                 async move {
+                    // Signal the fetcher body has been entered —
+                    // Actor A is past the cache-miss path and
+                    // registered in-flight before any Actor B work.
+                    let _ = fetcher_started_tx.send(());
                     go.notified().await;
                     Ok::<_, FetchError>(Some(E {
                         id,
@@ -432,10 +449,13 @@ async fn expired_concurrent_insert_does_not_block_single_flight_insert() {
             .await
     });
 
-    // Yield so Actor A registers the in-flight fetch + parks on the
-    // Notify before Actor B runs.
-    tokio::task::yield_now().await;
-    tokio::task::yield_now().await;
+    // Wait for Actor A to enter the fetcher (deterministic — the
+    // oneshot resolves only when the fetcher body runs, which only
+    // happens after Actor A's initial get-miss + single-flight
+    // registration).
+    fetcher_started_rx
+        .await
+        .expect("Actor A's fetcher must enter before Actor B inserts");
 
     // Step 3: Actor B inserts at id=1 with default 1s TTL.
     p.insert(E {

--- a/sassi/tests/punnu_single_flight.rs
+++ b/sassi/tests/punnu_single_flight.rs
@@ -365,22 +365,43 @@ async fn coalesced_awaiters_fire_insert_event_exactly_once() {
 /// Proof of the BLOCK-M2 fix: expired-conflict during a fetch must
 /// not leave the cache empty.
 ///
-/// Pre-fix scenario: with `OnConflict::Reject`, an existing entry's
-/// TTL elapses during a `get_or_fetch`. The on_fetched closure
-/// called `insert_arc_into_l1` which saw the still-present (expired
-/// but not yet popped) entry and returned `Conflict`. The fall-back
-/// `punnu.get(&id)` then ran the lazy-expiry path, popped the
-/// expired entry, and returned `None`. `unwrap_or(arc)` returned the
-/// freshly-fetched value to the caller — but it was never inserted.
-/// Subsequent `get(&id)` calls would miss, violating
-/// `get_or_fetch`'s documented post-condition.
+/// Multi-actor scenario the M2 BLOCK actually requires:
 ///
-/// The fix (`insert_arc_or_existing`) treats expired entries as
-/// absent and inserts the freshly-fetched value atomically under
-/// one L1 lock. `OnConflict::Reject` does not apply on this path.
+/// 1. Punnu configured with `OnConflict::Reject` + `default_ttl = 1s`.
+/// 2. Actor A starts a `get_or_fetch` for id=1. Initial `get(1)` is a
+///    miss (cache empty), so A registers an in-flight fetch and the
+///    fetcher closure runs. The fetcher awaits a Notify so the test
+///    can interleave Actor B's work before on_fetched fires.
+/// 3. Actor B independently `insert`s id=1 with the Punnu's default
+///    TTL (1s). The entry is now in L1.
+/// 4. Time advances past 1s. Actor B's entry is expired *but not
+///    popped* — no `get` has been called against id=1 since the
+///    insert.
+/// 5. The test signals A's fetcher to complete; A's on_fetched runs
+///    against an L1 that has Actor B's expired entry.
+///
+/// Pre-fix code path: on_fetched calls `insert_arc_into_l1`. Under
+/// `OnConflict::Reject`, the expired-but-present entry triggers
+/// `Conflict`. The fall-back `punnu.get(&id)` then lazy-pops the
+/// expired entry, returns `None`, and `unwrap_or(arc)` returns A's
+/// never-inserted value. L1 is now empty (B was popped, A was never
+/// inserted). Subsequent `get(1)` misses — violation of
+/// `get_or_fetch`'s post-condition.
+///
+/// Post-fix code path: on_fetched calls `insert_arc_or_existing`,
+/// which peeks under the L1 write lock, sees the expired entry,
+/// treats it as absent, and atomically replaces it with A's value.
+/// Subsequent `get(1)` hits with A's value.
+///
+/// The yield-and-Notify orchestration is what makes the test
+/// genuinely exercise on_fetched's expired-conflict path. A
+/// single-actor test (the previous version) gets short-circuited by
+/// `get_or_fetch`'s initial `get` which lazy-pops before on_fetched
+/// runs — the M2 race window doesn't open.
 #[tokio::test(start_paused = true)]
-async fn expired_existing_entry_does_not_block_single_flight_insert() {
+async fn expired_concurrent_insert_does_not_block_single_flight_insert() {
     use sassi::{OnConflict, PunnuConfig};
+    use tokio::sync::Notify;
 
     let p = Punnu::<E>::builder()
         .config(PunnuConfig {
@@ -390,45 +411,59 @@ async fn expired_existing_entry_does_not_block_single_flight_insert() {
         })
         .build();
 
-    // Original entry with 1s TTL.
+    // Step 2: Actor A starts get_or_fetch with a fetcher that awaits
+    // a Notify. Cache is empty → initial get(1) misses → registers
+    // in-flight fetch → fetcher runs → fetcher parks on Notify.
+    let go = Arc::new(Notify::new());
+    let go_for_fetch = go.clone();
+    let p_for_fetch = p.clone();
+    let actor_a = tokio::spawn(async move {
+        p_for_fetch
+            .get_or_fetch(&1, move |id| {
+                let go = go_for_fetch.clone();
+                async move {
+                    go.notified().await;
+                    Ok::<_, FetchError>(Some(E {
+                        id,
+                        name: "actor_a".into(),
+                    }))
+                }
+            })
+            .await
+    });
+
+    // Yield so Actor A registers the in-flight fetch + parks on the
+    // Notify before Actor B runs.
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    // Step 3: Actor B inserts at id=1 with default 1s TTL.
     p.insert(E {
         id: 1,
-        name: "original".into(),
+        name: "actor_b".into(),
     })
     .await
     .unwrap();
 
-    // Advance past the TTL — the entry is expired but not yet
-    // lazily popped (no `get` has been called).
+    // Step 4: advance past TTL. Actor B's entry is expired but not
+    // popped (no get since insert).
     tokio::time::advance(Duration::from_secs(2)).await;
 
-    // Trigger a get_or_fetch. The fetcher returns Some(new_value).
-    // Pre-fix: on_fetched hits Conflict because the expired entry
-    // is still in the LRU map; lazy `get` pops it; `unwrap_or(arc)`
-    // returns the never-inserted fresh value. Post-fix:
-    // insert_arc_or_existing treats the expired entry as absent and
-    // inserts the fresh value atomically.
-    let result = p
-        .get_or_fetch(&1, |id| async move {
-            Ok::<_, FetchError>(Some(E {
-                id,
-                name: "fresh".into(),
-            }))
-        })
-        .await
-        .unwrap()
-        .unwrap();
+    // Step 5: wake Actor A's fetcher. on_fetched runs against an L1
+    // with Actor B's expired entry.
+    go.notify_one();
 
-    assert_eq!(
-        result.name, "fresh",
-        "get_or_fetch returns the freshly-fetched value to the caller"
-    );
+    let result = actor_a.await.unwrap().unwrap().unwrap();
 
-    // Headline assertion: the freshly-fetched value is in L1.
-    // Subsequent get must hit, not miss. Pre-fix, it would miss
-    // (the value was never inserted under the Conflict-then-get path).
+    // Actor A always gets its value (this is true pre- and post-fix —
+    // the bug was about L1 state, not return value).
+    assert_eq!(result.name, "actor_a");
+
+    // Headline assertion: subsequent get must hit. Pre-fix this would
+    // miss (B was lazy-popped, A was never inserted). Post-fix, the
+    // atomic insert_arc_or_existing replaced B with A.
     let cached = p
         .get(&1)
-        .expect("subsequent get must hit; pre-fix it would miss");
-    assert_eq!(cached.name, "fresh");
+        .expect("subsequent get must hit; pre-fix L1 was empty after expired-conflict");
+    assert_eq!(cached.name, "actor_a");
 }

--- a/sassi/tests/punnu_ttl_lazy.rs
+++ b/sassi/tests/punnu_ttl_lazy.rs
@@ -1,4 +1,4 @@
-//! Task 6 — TTL lazy-expiry path.
+//! TTL lazy-expiry path.
 //!
 //! Spec §6.2.5: when an entry's `expires_at` deadline has passed,
 //! `Punnu::get` returns `None`, removes the entry from L1, and emits

--- a/sassi/tests/punnu_ttl_sweep.rs
+++ b/sassi/tests/punnu_ttl_sweep.rs
@@ -56,40 +56,33 @@ impl Cacheable for E {
 }
 
 /// Anchor the background sweep task's interval timer at the current
-/// virtual time.
+/// virtual time — deterministic version using the readiness handshake
+/// fired by `spawn_sweep` on its first poll.
 ///
 /// `tokio::spawn(...)` queues the sweep's future but doesn't poll it
 /// until the runtime yields; on a `current_thread` runtime under
 /// `#[tokio::test(start_paused = true)]`, that means the sweep's
-/// `tokio::time::interval` is constructed only after the test code
-/// yields. If we `advance` before the sweep has been polled, the
-/// interval anchors at the *advanced* time and the sweep wakes one
-/// interval *after* the advance — the test then sees no removal.
+/// initial sleep is registered only after the sweep is polled. If we
+/// `advance` before that happens, the sleep anchors at the *advanced*
+/// time and the sweep wakes one interval *after* the advance — the
+/// test then sees no removal.
 ///
-/// Calling `prime_sweep` after `Punnu::builder().build()` and any
-/// inserts forces the sweep to be polled at least once: it creates
-/// its interval, awaits the immediate first tick (the sweep skips
-/// it), and parks on the second tick. Subsequent `advance` calls
-/// will then fire the registered timer.
-///
-/// **Heuristic, not a guarantee.** Tokio does not formally guarantee
-/// scheduling order after [`tokio::task::yield_now`]; two yields
-/// cover the common case (current_thread runtime + paused clock +
-/// spawn-then-tick sequence) but a future scheduler change could
-/// make this flake. A `tokio::sync::Notify`-based handshake from
-/// the sweep task to the test would be deterministic; tracked for
-/// the v0.2 testing-helper refactor in
-/// <https://github.com/TarunvirBains/sassi/issues/4>. For v0.1.0,
-/// these tests have been stable across CI runs and the heuristic
-/// is acceptable.
-async fn prime_sweep() {
-    tokio::task::yield_now().await;
-    tokio::task::yield_now().await;
+/// `_test_sweep_initialised()` returns a `Notify` that the sweep
+/// fires on first poll, *before* the first sleep registers. Awaiting
+/// `notified()` here guarantees the first sleep is anchored at the
+/// test's current virtual time. Replaces the yield-count heuristic
+/// from Cluster A; closes
+/// <https://github.com/TarunvirBains/sassi/issues/4>.
+async fn prime_sweep<T: Cacheable>(p: &Punnu<T>) {
+    let notify = p
+        ._test_sweep_initialised()
+        .expect("test invoked prime_sweep but no ttl_sweep_interval was configured");
+    notify.notified().await;
 }
 
 /// Yield enough times for the background sweep loop to process its
 /// pending wake-ups after a `tokio::time::advance`. The sweep task's
-/// `tick.tick().await` is a wakeup point on the paused clock; one
+/// `executor.sleep(...)` is a wakeup point on the paused clock; one
 /// yield per tick we want to process is sufficient because the sweep
 /// does no awaits between ticks (it acquires the L1 lock
 /// synchronously, drains, releases).
@@ -115,7 +108,7 @@ async fn sweep_removes_expired_without_get() {
     assert_eq!(p.len(), 1);
 
     // Pin the sweep's interval timer at virtual t=0 before advancing.
-    prime_sweep().await;
+    prime_sweep(&p).await;
 
     // Advance past TTL and several sweep ticks. The sweep skips the
     // first immediate tick (see `spawn_sweep`), so we need a couple
@@ -142,7 +135,7 @@ async fn sweep_emits_ttl_expired_event() {
     let mut rx = p.events();
     p.insert(E { id: 7 }).await.unwrap();
 
-    prime_sweep().await;
+    prime_sweep(&p).await;
     tokio::time::advance(Duration::from_secs(10)).await;
     drive_sweep_ticks(4).await;
 
@@ -177,7 +170,7 @@ async fn sweep_does_not_remove_unexpired_entries() {
     p.insert(E { id: 1 }).await.unwrap();
 
     // Several sweep ticks pass without the TTL elapsing.
-    prime_sweep().await;
+    prime_sweep(&p).await;
     tokio::time::advance(Duration::from_secs(5)).await;
     drive_sweep_ticks(6).await;
     assert_eq!(p.len(), 1, "unexpired entry must survive the sweep");
@@ -201,7 +194,7 @@ async fn sweep_handles_mixed_expired_and_fresh() {
         .await
         .unwrap();
 
-    prime_sweep().await;
+    prime_sweep(&p).await;
     tokio::time::advance(Duration::from_secs(10)).await;
     drive_sweep_ticks(4).await;
 
@@ -252,7 +245,7 @@ async fn sweep_removes_on_configured_tick_boundary() {
         .build();
     p.insert(E { id: 1 }).await.unwrap();
 
-    prime_sweep().await;
+    prime_sweep(&p).await;
 
     // Just past the first sweep tick — entry not yet expired.
     tokio::time::advance(Duration::from_millis(1500)).await;

--- a/sassi/tests/punnu_ttl_sweep.rs
+++ b/sassi/tests/punnu_ttl_sweep.rs
@@ -1,4 +1,4 @@
-//! Task 6 — TTL background-sweep path.
+//! TTL background-sweep path.
 //!
 //! Spec §6.2.5: when [`PunnuConfig::ttl_sweep_interval`] is `Some`,
 //! a background task scans the L1 every interval tick, removes
@@ -70,8 +70,8 @@ impl Cacheable for E {
 /// `_test_sweep_initialised()` returns a `Notify` that the sweep
 /// fires on first poll, *before* the first sleep registers. Awaiting
 /// `notified()` here guarantees the first sleep is anchored at the
-/// test's current virtual time. Replaces the yield-count heuristic
-/// from Cluster A; closes
+/// test's current virtual time. Replaces the previous yield-count
+/// heuristic; closes
 /// <https://github.com/TarunvirBains/sassi/issues/4>.
 async fn prime_sweep<T: Cacheable>(p: &Punnu<T>) {
     let notify = p


### PR DESCRIPTION
## Cluster B — Runtime decoupling + single-flight fetch + config polish

Implements Tasks 7, 8, 10 of the sassi v0.1.0-alpha plan. Task 10 landed first to decouple sassi from tokio's runtime before Tasks 7 and 8 layered new features on top.

### What lands

- **Task 10 (`PunnuExecutor` abstraction):** `pub(crate) trait PunnuExecutor` with `spawn` / `sleep` / `now` primitives; `DefaultExecutor` cfg-gated for native (tokio) vs wasm32 (`wasm_bindgen_futures::spawn_local` + `gloo_timers::TimeoutFuture`). TTL sweep refactored to route through `executor.spawn` + `executor.sleep`. Replaced the Cluster A yield-count `prime_sweep` heuristic with a deterministic `tokio::sync::Notify` handshake exposed via `Punnu::_test_sweep_initialised()`. Workspace deps: `web-time = "1"`, `wasm-bindgen-futures = "0.4"`, `gloo-timers = "0.4"`. WASM CI job added.
- **Instant abstraction:** picked **Option C** (target-cfg type alias `crate::time::Instant`) over the resolution-plan's Options A/B. Native = `tokio::time::Instant` (preserves `tokio::time::pause()` / `advance(...)` for test determinism). Wasm = `web_time::Instant` (browser `Performance.now()`). Investigation showed Option B (web_time everywhere) doesn't compose with tokio's paused-clock test primitives — would force a sweeping test rewrite. Option C keeps tests deterministic while delivering the wasm story. The executor's `now()` method returns the alias.
- **Task 7 (single-flight fetch):** `Punnu::get_or_fetch(id, fetcher)` + `Punnu::get_or_fetch_many(&[ids], batch_fetcher)`. Single-flight registry stores `DashMap<T::Id, Weak<Shared<...>>>` — Weak in the registry, Arc on the awaiters — so case-2 cancellation (all awaiters drop) actually drops the underlying fetch future rather than degrading to "fetch runs to completion with no observers, registry leaks until next call". Atomic registration via `DashMap::Entry`. Cancellation contract per spec §3.5.1 covers all four owner-loss cases (originator-drop-with-peers, all-awaiters-drop, fetcher-panic, caller-imposed deadline) with deterministic outcomes. New `FetchError` enum with `#[non_exhaustive]` seal; clone-friendly internal `FetchErrorClone` carrier inside `Shared`.
- **Task 8 (namespace + metrics):** wired every `PunnuMetrics` callback into the right call site — hits, misses, evictions (manual / LRU / TTL-lazy / TTL-sweep), LRU size sampling, fetch latency. `record_*` no-ops when `metrics: None` (single null-check, zero cost). Metrics fired outside the L1 lock scope. Empty-string namespace rejected at builder time (degenerate-config guard, matches the Cluster A treatment of `lru_size=0` and zero ttl_sweep_interval).

### Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace` ✓ (93 tests, +26 over Cluster A)
- `cargo test -p sassi --no-default-features` ✓
- `cargo build -p sassi --target wasm32-unknown-unknown --no-default-features --features "serde,runtime-wasm"` ✓ (verified locally; CI job pins it for every PR)
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features` ✓

### Closes

- #4 (deterministic sweep handshake — `tokio::sync::Notify` replaces the yield-count heuristic; `prime_sweep` rewritten across all six TTL sweep tests)

### Partially resolves

- #3 (WASM target) — sassi compiles for `wasm32-unknown-unknown` under `runtime-wasm`; CI matrix expansion to a full multi-target test grid (with `wasm-bindgen-test`) is Task 18 territory. The placeholder `punnu_executor_wasm.rs` reserves the test path for that work.

### Codex-block-patterns walk (pre-empted)

- **G (API surface):** `FetchError` is `#[non_exhaustive]`; `FetchErrorClone`, `RenderedError`, `InFlightRegistry` are `pub(crate)` or private. No new `pub` field reachability past typed wrappers.
- **H (validation depth):** empty-string namespace rejected at builder; matches the existing degenerate-value posture.
- **C (locking):** every metrics `record_*` fires outside the L1 lock scope; sweep loop drops the lock before broadcast + metric calls.
- **M (concurrency):** single-flight registry uses `DashMap::Entry` for atomic probe + insert (M1); cancellation contract enumerated in spec §3.5.1 with explicit module-level docs covering all four owner-loss cases (M3) — verified with tests for cases 1, 2, 3 (case 4 composes via `tokio::time::timeout`).

### Plan

Tasks 7, 8, 10 of `docs/superpowers/plans/2026-05-01-sassi-v0.1.0.md`.