### PR TITLE
Prepare Sassi 0.1.0 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.1.0-beta.1] - 2026-05-07
+
+### Added
+
+- Added `IntoBasicPredicate<T>` so downstream crates can expose provenanced
+  predicate wrappers while still feeding Punnu's in-memory evaluator.
+- Added `PresentField<T, V>` and `Field<T, Option<V>>::some()` for comparing
+  only present optional values without treating `None` as an inner default.
+- Added `CacheableFieldsMode::External` for downstream macro crates that own
+  their own `Cacheable::Fields` companion type.
+
+### Changed
+
+- Made `PunnuScope::filter_basic` and `MemQ::filter_basic` accept
+  `IntoBasicPredicate<T>`.
+- Made `BasicPredicate<T>` clone structurally without imposing `T: Clone`.
+- Changed case-insensitive string predicates to ASCII-only folding so portable
+  in-memory semantics can be mirrored exactly by database emitters.
+- Made `retry_delay_for_attempt` internal; retry backoff remains covered by
+  crate-local tests without exposing the helper as public API.
+- Updated public docs and crate metadata for the `0.1.0-beta.1` release line.
+- Documented `sassi-macros` and `sassi-codegen` as support crates; ordinary
+  adopters depend on `sassi` and optionally `sassi-cache-redis`.
+- Documented Redis `invalidate_all` as best-effort across the delete/publish
+  boundary.
+
+### Fixed
+
+- Suppressed local `get_async` L2 rehydration for ids whose best-effort backend
+  invalidation failed, preventing stale backend values from being resurrected in
+  the same process.
+- Restored delta-refresh recovery snapshots and primed subscription membership
+  when a panic occurs after recovery query preparation.
+
 ## [0.1.0-alpha.2] - 2026-05-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bardownski"
-version = "0.1.0-alpha.3"
+version = "0.1.0-beta.1"
 dependencies = [
  "clap",
  "crossterm",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "sassi"
-version = "0.1.0-alpha.3"
+version = "0.1.0-beta.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "sassi-cache-redis"
-version = "0.1.0-alpha.3"
+version = "0.1.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "sassi-codegen"
-version = "0.1.0-alpha.3"
+version = "0.1.0-beta.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "sassi-macros"
-version = "0.1.0-alpha.3"
+version = "0.1.0-beta.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-alpha.3"
+version = "0.1.0-beta.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/TarunvirBains/sassi"

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ of the WASM build, not a separately certified integration here.
 
 ## Status
 
-Sassi is preparing its first public alpha: `0.1.0-alpha.2`. The core API,
+Sassi is preparing its first public beta: `0.1.0-beta.1`. The core API,
 Redis companion, Bardownski TUI example, benchmark harness, and adopter docs are
-in place, with the usual caution that alpha APIs can still move as real adopters
-put pressure on the design.
+in place, with the caution that beta APIs can still move when integration work
+finds correctness or ergonomics gaps.
 
-The current alpha minimum supported Rust version is 1.95 (set in
+The current beta minimum supported Rust version is 1.95 (set in
 `[workspace.package].rust-version`).
 
 Adopter feedback is welcome. If Sassi looks useful but a workflow is unclear,
@@ -139,26 +139,31 @@ Bardownski implementation is planned outside this repository.
 
 ```text
 sassi/              # library crate
-sassi-codegen/      # shared code generation used by sassi macros
-sassi-macros/       # proc macros
+sassi-codegen/      # support crate for macro/codegen integrations
+sassi-macros/       # support proc-macro crate re-exported by sassi
 sassi-cache-redis/  # Redis CacheBackend companion crate
 examples/bardownski/ # dependency-light TUI showcase
 ```
 
+Most adopters add only `sassi` to `Cargo.toml`, plus `sassi-cache-redis` when
+Redis L2 support is needed. `sassi-macros` and `sassi-codegen` are published
+support crates for Sassi's derive macros and downstream macro integrations; they
+are not part of the ordinary application dependency story.
+
 ## Documentation
 
-- [Getting Started](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/docs/getting-started.md)
-- [Concepts](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/docs/concepts.md)
-- [Query And Refresh Boundaries](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/docs/query-refresh-boundaries.md)
-- [Backends And Runtimes](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/docs/backends-and-runtimes.md)
-- [Release Readiness](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/docs/release-readiness.md)
-- [Bardownski TUI Showcase](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/examples/bardownski/README.md)
-- [Benchmarks](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/sassi/benches/README.md)
-- [Changelog](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/CHANGELOG.md)
+- [Getting Started](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/docs/getting-started.md)
+- [Concepts](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/docs/concepts.md)
+- [Query And Refresh Boundaries](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/docs/query-refresh-boundaries.md)
+- [Backends And Runtimes](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/docs/backends-and-runtimes.md)
+- [Release Readiness](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/docs/release-readiness.md)
+- [Bardownski TUI Showcase](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/examples/bardownski/README.md)
+- [Benchmarks](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/sassi/benches/README.md)
+- [Changelog](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/CHANGELOG.md)
 
 ## License
 
 Dual-licensed under
-[MIT](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/LICENSE-MIT)
+[MIT](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/LICENSE-MIT)
 or
-[Apache-2.0](https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/LICENSE-APACHE).
+[Apache-2.0](https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/LICENSE-APACHE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Start here:
 - [Backends And Runtimes](backends-and-runtimes.md) describes L1/L2 behavior,
   built-in backends, Redis, native Tokio, WASM, and framework integration
   boundaries.
-- [Release Readiness](release-readiness.md) records the v0.1.0-alpha scope,
+- [Release Readiness](release-readiness.md) records the v0.1.0-beta.1 scope,
   known deferrals, issue categories, and verification commands.
 - [Bardownski TUI Showcase](../examples/bardownski/README.md) is the in-repo
   native example for predicate algebra and cross-type trait queries over

--- a/docs/backends-and-runtimes.md
+++ b/docs/backends-and-runtimes.md
@@ -140,6 +140,12 @@ Redis and be read back later. Applications that need a global write barrier
 should coordinate writes outside Sassi, move to a new namespace, or use a backend
 design with generation tokens.
 
+`invalidate_all` is also best-effort across the delete-and-publish boundary. It
+deletes Redis entries in committed batches before publishing the final
+keyspace-wide invalidation message. If that final publish fails, Sassi does not
+roll back deleted Redis entries, and other processes can retain stale L1 entries
+until a later invalidation, refresh, restart, or namespace/generation rollover.
+
 `RedisBackend` drains index keys in bounded chunks, so `invalidate_all` may run
 for a long time under sustained concurrent writes.
 
@@ -150,8 +156,8 @@ script effects replication.
 
 ```toml
 [dependencies]
-sassi = "0.1.0-alpha.2"
-sassi-cache-redis = "0.1.0-alpha.2"
+sassi = "0.1.0-beta.1"
+sassi-cache-redis = "0.1.0-beta.1"
 ```
 
 ## Backend Failure Modes
@@ -173,12 +179,26 @@ and `start_delta_refresh` apply fetched values to the in-process L1 map; they do
 not write those fetched values through to L2 or publish L2 invalidations for
 query membership changes.
 
+In best-effort modes (`L1Only` and exhausted `Retry`), a failed single-id
+backend invalidation suppresses future `get_async` L2 rehydration for that id in
+the same process. The suppression is set before the local L1 entry is removed,
+so concurrent same-id `get_async` calls cannot rehydrate L2 while backend
+invalidation is in flight. Suppression is cleared after a later local backend
+write or local backend invalidation for that id succeeds. Backend invalidation
+stream delivery does not clear it because streams do not carry an ordering token
+relative to this process's failed invalidation. Suppression is per-id and is not
+capped by the L1 `lru_size`, so a prolonged backend outage can retain one local
+suppression entry per failed invalidation. This prevents a local pool from
+resurrecting a value it explicitly invalidated during an L2 outage, but it is not
+a distributed generation-token guarantee for other processes.
+
 ### L1/L2 Access Boundaries
 
 `get` is L1-only.
 
 `get_async` checks L1 first, then backend, and finally inserts the backend value
-into L1 if canonical.
+into L1 if canonical. It skips the backend read when a prior best-effort
+invalidation failure marked that id as locally untrusted.
 
 `get_or_fetch` and `get_or_fetch_many` are canonical-id fetch helpers. They do
 not `put` back to L2, and they should not be used as query/page-style membership
@@ -253,7 +273,7 @@ For `wasm32-unknown-unknown`, enable `runtime-wasm`:
 
 ```toml
 sassi = {
-    version = "0.1.0-alpha.2",
+    version = "0.1.0-beta.1",
     default-features = false,
     features = ["serde", "runtime-wasm"],
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ The default feature set enables `serde` and the native Tokio runtime path:
 
 ```toml
 [dependencies]
-sassi = "0.1.0-alpha.2"
+sassi = "0.1.0-beta.1"
 tokio = { version = "1", features = ["macros", "rt"] }
 ```
 
@@ -109,7 +109,7 @@ when the caller needs positional lookup.
 only when you want an L1-only in-process cache with the smallest surface:
 
 ```toml
-sassi = { version = "0.1.0-alpha.2", default-features = false }
+sassi = { version = "0.1.0-beta.1", default-features = false }
 ```
 
 `runtime-tokio` is the native background-work path. It is selected by default
@@ -122,7 +122,7 @@ explicitly for browser/WASM targets:
 
 ```toml
 sassi = {
-    version = "0.1.0-alpha.2",
+    version = "0.1.0-beta.1",
     default-features = false,
     features = ["serde", "runtime-wasm"],
 }
@@ -133,7 +133,7 @@ for selected `time` and `chrono` timestamp types. They are useful when a delta
 sync cursor is already represented by one of those libraries:
 
 ```toml
-sassi = { version = "0.1.0-alpha.2", features = ["watermark-time"] }
+sassi = { version = "0.1.0-beta.1", features = ["watermark-time"] }
 ```
 
 ## Where Next

--- a/docs/red-team-release-gate.md
+++ b/docs/red-team-release-gate.md
@@ -68,10 +68,10 @@ publish decision:
 Use these publish decisions:
 
 - `BLOCK`: do not publish until fixed or disproven.
-- `FIX_BEFORE_ALPHA`: fix before this alpha because the blast radius is real.
-- `DOC_BEFORE_ALPHA`: code behavior is acceptable for alpha, but docs/API
+- `FIX_BEFORE_RELEASE`: fix before this release because the blast radius is real.
+- `DOC_BEFORE_RELEASE`: code behavior is acceptable for this release, but docs/API
   wording can cause dangerous misuse.
-- `POST_ALPHA`: worth tracking, not release-blocking.
+- `POST_RELEASE`: worth tracking, not release-blocking.
 - `NO_ACTION`: checked and safe enough with current evidence.
 
 Confirmed bugs outrank speculative hardening. A suspicious area becomes a
@@ -193,12 +193,12 @@ and release goals.
 Before publishing, there should be:
 
 - no unresolved `BLOCK` findings;
-- no unresolved `FIX_BEFORE_ALPHA` findings unless the release is intentionally
+- no unresolved `FIX_BEFORE_RELEASE` findings unless the release is intentionally
   delayed or rescoped;
-- `DOC_BEFORE_ALPHA` findings either documented or consciously promoted to code
+- `DOC_BEFORE_RELEASE` findings either documented or consciously promoted to code
   fixes;
 - a short issue register recording what was fixed, what was documented, and what
-  remains post-alpha;
+  remains after this release;
 - targeted tests for every fixed bug;
 - full release verification rerun after the final patch set.
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,13 +1,13 @@
 # Release Readiness
 
-Sassi v0.1.0-alpha is meant to be usable by capable Rust adopters who are
-willing to work with an early API surface. The goal is not to claim that every
-future integration is done; it is to make the current contracts, tradeoffs, and
-verification expectations visible before publish.
+Sassi v0.1.0-beta.1 is meant to be usable by capable Rust adopters who are
+willing to work with an early but candidate API surface. The goal is not to
+claim that every future integration is done; it is to make the current
+contracts, tradeoffs, and verification expectations visible before publish.
 
-## v0.1.0-alpha Scope
+## v0.1.0-beta.1 Scope
 
-In scope for the alpha:
+In scope for the beta:
 
 - `Cacheable` and `#[derive(Cacheable)]` for typed identity.
 - `Punnu<T>` as an in-process resident union identity map.
@@ -31,9 +31,9 @@ In scope for the alpha:
   [benchmark baselines](../sassi/benches/README.md) for same-host regression
   tracking of public cache surfaces.
 
-## Out Of Scope For This Alpha
+## Out Of Scope For This Beta
 
-These are intentionally not release claims for v0.1.0-alpha:
+These are intentionally not release claims for v0.1.0-beta.1:
 
 - Full downstream data-layer integration examples.
 - The Bardownski Dioxus/full-stack implementation.
@@ -66,7 +66,7 @@ include:
 
 ## Verification Before Publish
 
-Before publishing an alpha, run the commands below from the repository root and
+Before publishing a beta, run the commands below from the repository root and
 record the results in the release notes or publish checklist:
 
 ```bash

--- a/examples/bardownski/Cargo.toml
+++ b/examples/bardownski/Cargo.toml
@@ -15,5 +15,5 @@ clap = { workspace = true }
 csv = { workspace = true }
 crossterm = { workspace = true }
 ratatui = { workspace = true }
-sassi = { path = "../../sassi", version = "0.1.0-alpha.3", default-features = false }
+sassi = { path = "../../sassi", version = "0.1.0-beta.1", default-features = false }
 serde = { workspace = true }

--- a/sassi-cache-redis/Cargo.toml
+++ b/sassi-cache-redis/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["cache", "redis", "invalidation"]
 categories = ["caching"]
 
 [dependencies]
-sassi = { path = "../sassi", version = "0.1.0-alpha.3" }
+sassi = { path = "../sassi", version = "0.1.0-beta.1" }
 async-trait = { workspace = true }
 async-stream = "0.3"
 futures = { workspace = true }

--- a/sassi-cache-redis/README.md
+++ b/sassi-cache-redis/README.md
@@ -7,8 +7,8 @@ providing shared L2 storage plus an explicit invalidation pub/sub path.
 
 ```toml
 [dependencies]
-sassi = "0.1.0-alpha.2"
-sassi-cache-redis = "0.1.0-alpha.2"
+sassi = "0.1.0-beta.1"
+sassi-cache-redis = "0.1.0-beta.1"
 ```
 
 The backend uses the `BackendKeyspace` supplied by `PunnuConfig::namespace` and
@@ -40,7 +40,13 @@ drain can survive in Redis and be read back later. Coordinate writers outside
 Sassi or move to a new namespace when a deployment needs a true generation
 boundary.
 
+`invalidate_all` may also partially succeed. It deletes Redis entries in
+committed batches before publishing the final keyspace-wide invalidation
+message. If that final publish fails, deleted Redis entries are not rolled back,
+and other processes can retain stale L1 entries until a later invalidation,
+refresh, restart, or namespace/generation rollover.
+
 See the Sassi repository docs for the broader cache model and release notes:
 
-- https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/docs/backends-and-runtimes.md
-- https://github.com/TarunvirBains/sassi/blob/v0.1.0-alpha.2/docs/release-readiness.md
+- https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/docs/backends-and-runtimes.md
+- https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.1/docs/release-readiness.md

--- a/sassi-codegen/Cargo.toml
+++ b/sassi-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sassi-codegen"
-description = "Shared codegen primitives for sassi-macros and downstream proc-macro consumers."
+description = "Support crate for Sassi macro/codegen integrations; most adopters depend on sassi directly."
 readme = "../README.md"
 version.workspace = true
 edition.workspace = true

--- a/sassi-codegen/src/cacheable_impl.rs
+++ b/sassi-codegen/src/cacheable_impl.rs
@@ -7,13 +7,13 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Data, DeriveInput, Field, Fields};
 
-use crate::derive_options::CacheableDeriveOptions;
+use crate::derive_options::{CacheableDeriveOptions, CacheableFieldsMode};
 
 /// Emit `impl Cacheable for T`:
 ///
 /// 1. `type Id` — set to the type of the field literally named `id`.
-/// 2. `type Fields` — set to `{Name}Fields` (companion struct produced
-///    by [`generate_fields_struct`](super::fields_struct::generate_fields_struct)).
+/// 2. `type Fields` — set to `{Name}Fields` by default, or to the
+///    external field companion named by [`CacheableFieldsMode::External`].
 /// 3. `fn cache_type_name()` — returns either `#[cacheable(type_name = "...")]`
 ///    or `std::any::type_name::<Self>()`.
 /// 4. `fn id(&self) -> Self::Id` — clones `self.id`.
@@ -56,19 +56,36 @@ pub fn generate_cacheable_impl(
         quote! { std::any::type_name::<Self>() }
     };
 
-    // For each declared field, emit `name: Field::new("name", |s| &s.name)`.
-    let field_constructors = named.iter().map(|f| {
-        let name = f.ident.as_ref().unwrap();
-        let name_str = name.to_string();
-        quote! {
-            #name: #sassi_path::Field::new(#name_str, |s| &s.#name)
+    let (fields_type, fields_constructor) = match &options.fields {
+        CacheableFieldsMode::Generated => {
+            // For each declared field, emit `name: Field::new("name", |s| &s.name)`.
+            let field_constructors = named.iter().map(|f| {
+                let name = f.ident.as_ref().unwrap();
+                let name_str = name.to_string();
+                quote! {
+                    #name: #sassi_path::Field::new(#name_str, |s| &s.#name)
+                }
+            });
+
+            (
+                quote! { #fields_name },
+                quote! {
+                    #fields_name {
+                        #(#field_constructors,)*
+                    }
+                },
+            )
         }
-    });
+        CacheableFieldsMode::External {
+            type_path,
+            constructor,
+        } => (quote! { #type_path }, quote! { #constructor }),
+    };
 
     Ok(quote! {
         impl #sassi_path::Cacheable for #struct_name {
             type Id = #id_ty;
-            type Fields = #fields_name;
+            type Fields = #fields_type;
 
             fn cache_type_name() -> &'static str {
                 #cache_type_name
@@ -79,9 +96,7 @@ pub fn generate_cacheable_impl(
             }
 
             fn fields() -> Self::Fields {
-                #fields_name {
-                    #(#field_constructors,)*
-                }
+                #fields_constructor
             }
         }
     })

--- a/sassi-codegen/src/derive_options.rs
+++ b/sassi-codegen/src/derive_options.rs
@@ -1,6 +1,6 @@
 //! Parsing support for `#[derive(Cacheable)]` helper attributes.
 
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream};
 use syn::{Data, DeriveInput, Fields, LitStr, spanned::Spanned};
 
 /// Parsed options from `#[cacheable(...)]` helper attributes.
@@ -10,6 +10,28 @@ pub struct CacheableDeriveOptions {
     pub watermark_field: Option<WatermarkField>,
     /// Optional stable L2 backend keyspace type name.
     pub type_name: Option<CacheTypeName>,
+    /// Companion field surface used for `Cacheable::Fields`.
+    pub fields: CacheableFieldsMode,
+}
+
+/// Companion field-surface mode for generated `Cacheable` impls.
+#[derive(Debug, Default)]
+pub enum CacheableFieldsMode {
+    /// Use sassi-codegen's generated `{Model}Fields` companion and construct
+    /// one `sassi::Field<Model, V>` accessor per model field.
+    #[default]
+    Generated,
+    /// Reference a consumer-owned companion type and constructor expression.
+    ///
+    /// Downstream macro crates use this when they already generate their own
+    /// `{Model}Fields` type and need only the `Cacheable` impl from
+    /// sassi-codegen.
+    External {
+        /// Token path for `type Fields = ...`.
+        type_path: TokenStream,
+        /// Expression used by `fn fields() -> Self::Fields`.
+        constructor: TokenStream,
+    },
 }
 
 /// Name and source span for a requested watermark field.
@@ -54,6 +76,22 @@ impl CacheTypeName {
         Self {
             value: value.into(),
             span,
+        }
+    }
+}
+
+impl CacheableFieldsMode {
+    /// Construct an external field companion mode.
+    ///
+    /// `type_path` is emitted after `type Fields =`; `constructor` is emitted
+    /// as the body expression of `fn fields() -> Self::Fields`.
+    pub fn external(
+        type_path: impl Into<TokenStream>,
+        constructor: impl Into<TokenStream>,
+    ) -> Self {
+        Self::External {
+            type_path: type_path.into(),
+            constructor: constructor.into(),
         }
     }
 }

--- a/sassi-codegen/src/lib.rs
+++ b/sassi-codegen/src/lib.rs
@@ -1,13 +1,16 @@
 //! # sassi-codegen
 //!
-//! Shared codegen primitives for `sassi-macros` and downstream
+//! Support crate with codegen primitives for `sassi-macros` and downstream
 //! proc-macro consumers (e.g., `djogi-macros`).
+//!
+//! Ordinary adopters depend on `sassi`, not this crate directly.
 //!
 //! Proc-macro crates can't depend on each other directly, but they can
 //! share a regular library crate. `sassi-codegen` is that library: it
 //! emits `TokenStream`s for `Cacheable` derive output (the companion
 //! `{Name}Fields` struct, the `Cacheable` impl, stable backend type-name
-//! support, the `T::fields()` constructor, and optional `DeltaSyncCacheable`
+//! support, the `T::fields()` constructor, optional external field-companion
+//! routing for downstream macro crates, and optional `DeltaSyncCacheable`
 //! impls). Each entry
 //! point takes a `sassi_path: &TokenStream` parameter so the caller can
 //! target whatever path prefix the end-user crate exposes (`::sassi`
@@ -32,6 +35,7 @@ mod fields_struct;
 
 pub use cacheable_impl::{generate_cacheable_impl, generate_delta_sync_cacheable_impl};
 pub use derive_options::{
-    CacheTypeName, CacheableDeriveOptions, WatermarkField, parse_cacheable_derive_options,
+    CacheTypeName, CacheableDeriveOptions, CacheableFieldsMode, WatermarkField,
+    parse_cacheable_derive_options,
 };
 pub use fields_struct::generate_fields_struct;

--- a/sassi-codegen/tests/external_fields.rs
+++ b/sassi-codegen/tests/external_fields.rs
@@ -1,0 +1,49 @@
+use quote::quote;
+use sassi_codegen::{
+    CacheableDeriveOptions, CacheableFieldsMode, generate_cacheable_impl, generate_fields_struct,
+};
+use syn::{DeriveInput, parse_quote};
+
+#[test]
+fn generated_mode_still_emits_standard_fields_constructor() {
+    let input: DeriveInput = parse_quote! {
+        struct User {
+            id: i64,
+            name: String,
+        }
+    };
+
+    let fields = generate_fields_struct(&input, &quote!(::sassi)).unwrap();
+    let cacheable =
+        generate_cacheable_impl(&input, &CacheableDeriveOptions::default(), &quote!(::sassi))
+            .unwrap();
+
+    let fields = fields.to_string();
+    let cacheable = cacheable.to_string();
+
+    assert!(fields.contains("struct UserFields"));
+    assert!(cacheable.contains("type Fields = UserFields"));
+    assert!(cacheable.contains("name : :: sassi :: Field :: new"));
+}
+
+#[test]
+fn external_fields_mode_uses_consumer_owned_type_and_constructor() {
+    let input: DeriveInput = parse_quote! {
+        struct User {
+            id: i64,
+            name: String,
+        }
+    };
+    let options = CacheableDeriveOptions {
+        fields: CacheableFieldsMode::external(quote!(UserFields), quote!(UserFields::new())),
+        ..Default::default()
+    };
+
+    let cacheable = generate_cacheable_impl(&input, &options, &quote!(::sassi))
+        .unwrap()
+        .to_string();
+
+    assert!(cacheable.contains("type Fields = UserFields"));
+    assert!(cacheable.contains("fn fields () -> Self :: Fields { UserFields :: new () }"));
+    assert!(!cacheable.contains("name : :: sassi :: Field :: new"));
+}

--- a/sassi-macros/Cargo.toml
+++ b/sassi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sassi-macros"
-description = "Proc macros for sassi (#[derive(Cacheable)], #[sassi::trait_impl])."
+description = "Support proc-macro crate re-exported by sassi for ordinary adopters."
 readme = "../README.md"
 version.workspace = true
 edition.workspace = true
@@ -20,7 +20,7 @@ proc-macro2 = { workspace = true }
 proc-macro-crate = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
-sassi-codegen = { path = "../sassi-codegen", version = "0.1.0-alpha.3" }
+sassi-codegen = { path = "../sassi-codegen", version = "0.1.0-beta.1" }
 
 [dev-dependencies]
 sassi = { path = "../sassi" }

--- a/sassi-macros/src/lib.rs
+++ b/sassi-macros/src/lib.rs
@@ -1,7 +1,9 @@
 //! # sassi-macros
 //!
-//! Proc macros for sassi: `#[derive(Cacheable)]` and
+//! Support proc-macro crate for Sassi: `#[derive(Cacheable)]` and
 //! `#[sassi::trait_impl]`.
+//!
+//! Ordinary adopters depend on `sassi`, which re-exports these macros.
 //!
 //! Macros call into `sassi-codegen` for the actual `TokenStream`
 //! emission so the codegen logic stays in a regular library crate

--- a/sassi-macros/tests/renamed_dependency.rs
+++ b/sassi-macros/tests/renamed_dependency.rs
@@ -25,6 +25,8 @@ version = "0.0.0"
 edition = "2024"
 rust-version = "1.95"
 
+[workspace]
+
 [dependencies]
 cache = {{ package = "sassi", path = "{}" }}
 "#,

--- a/sassi/Cargo.toml
+++ b/sassi/Cargo.toml
@@ -48,7 +48,7 @@ fastrand = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
-sassi-macros = { path = "../sassi-macros", version = "0.1.0-alpha.3" }
+sassi-macros = { path = "../sassi-macros", version = "0.1.0-beta.1" }
 inventory = { workspace = true }
 # `web-time` is a drop-in for `std::time::Instant` that works on
 # `wasm32-unknown-unknown`. Used only on wasm — native builds keep

--- a/sassi/benches/punnu_bench.rs
+++ b/sassi/benches/punnu_bench.rs
@@ -20,6 +20,7 @@
 //! throughput claims are derived from these numbers.
 
 use std::collections::{HashSet, VecDeque};
+use std::hint::black_box;
 #[cfg(all(
     feature = "serde",
     feature = "runtime-tokio",
@@ -36,7 +37,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use futures::{future::join_all, join};
 #[cfg(all(
     feature = "serde",

--- a/sassi/src/executor.rs
+++ b/sassi/src/executor.rs
@@ -1,7 +1,7 @@
 //! [`PunnuExecutor`] — internal abstraction over runtime spawn / sleep
 //! / now primitives.
 //!
-//! This is crate-internal in v0.1.0-alpha. The public runtime surface stays
+//! This is crate-internal in v0.1.0-beta.1. The public runtime surface stays
 //! focused on feature selection (`runtime-tokio` or `runtime-wasm`) while the
 //! crate keeps scheduling and clock reads behind one internal trait.
 //!
@@ -32,7 +32,7 @@
 //! preserves that determinism without exposing a tokio-specific knob
 //! to consumers. The wasm-target counterpart wraps
 //! [`web_time::Instant`] (which uses `Performance.now()` in the
-//! browser). Direct WASM runtime tests are outside the current v0.1.0-alpha
+//! browser). Direct WASM runtime tests are outside the current v0.1.0-beta.1
 //! release gate.
 
 use crate::time::Instant;

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -9,7 +9,7 @@
 //! `!` operators and evaluate through the same in-memory path on every
 //! supported target.
 //!
-//! Pre-v0.1.0 alpha. The core public surface is available now:
+//! Pre-v0.1.0 beta. The core public surface is available now:
 //! [`Cacheable`] identities, [`Punnu<T>`](Punnu) pools, in-memory
 //! [`MemQ`] scopes, lazy fetch helpers, TTL/LRU policy, event streams,
 //! and atomic delta application.
@@ -79,7 +79,9 @@ pub use cacheable::{Cacheable, Field};
 #[cfg(feature = "serde")]
 pub use error::WireFormatError;
 pub use error::{BackendError, FetchError, InsertError};
-pub use predicate::{BasicPredicate, FieldPredicate, LookupOp, MemQ};
+pub use predicate::{
+    BasicPredicate, FieldPredicate, IntoBasicPredicate, LookupOp, MemQ, PresentField,
+};
 pub use punnu::{
     BackendFailureMode, CacheTier, DeltaApplyStats, DeltaPunnuFetcher, DeltaQuery,
     DeltaRefreshHandle, DeltaResult, EventReason, InvalidationReason, OnConflict, Punnu,

--- a/sassi/src/predicate/basic.rs
+++ b/sassi/src/predicate/basic.rs
@@ -30,7 +30,7 @@ use std::ops::{BitAnd, BitOr, BitXor, Not};
 /// let alice = User { age: 30, banned: false };
 /// assert!(active_adult.evaluate(&alice));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum BasicPredicate<T> {
     /// Always-true sentinel. Useful as an identity for `And` reductions.
@@ -52,6 +52,37 @@ pub enum BasicPredicate<T> {
     /// Exclusive or — `a XOR b`. Not flattened (XOR isn't associative
     /// the way And/Or are when chained).
     Xor(Box<BasicPredicate<T>>, Box<BasicPredicate<T>>),
+}
+
+impl<T> Clone for BasicPredicate<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::True => Self::True,
+            Self::False => Self::False,
+            Self::Field(field) => Self::Field(field.clone()),
+            Self::And(parts) => Self::And(parts.clone()),
+            Self::Or(parts) => Self::Or(parts.clone()),
+            Self::Not(inner) => Self::Not(Box::new((**inner).clone())),
+            Self::Xor(left, right) => {
+                Self::Xor(Box::new((**left).clone()), Box::new((**right).clone()))
+            }
+        }
+    }
+}
+
+/// Conversion into the SQL-projectable base predicate algebra.
+///
+/// This lets downstream crates expose their own provenanced predicate wrapper
+/// while still feeding Punnu's in-memory evaluator.
+pub trait IntoBasicPredicate<T> {
+    /// Convert into a Sassi [`BasicPredicate<T>`].
+    fn into_basic_predicate(self) -> BasicPredicate<T>;
+}
+
+impl<T> IntoBasicPredicate<T> for BasicPredicate<T> {
+    fn into_basic_predicate(self) -> BasicPredicate<T> {
+        self
+    }
 }
 
 impl<T> BasicPredicate<T> {

--- a/sassi/src/predicate/field_ext.rs
+++ b/sassi/src/predicate/field_ext.rs
@@ -12,17 +12,20 @@
 //! so downstream walkers (SQL emitters, debug formatters) can
 //! downcast and inspect. Layout per op is documented on [`LookupOp`].
 //!
-//! Case-insensitive string ops use `str::eq_ignore_ascii_case` and
-//! `to_lowercase()` rather than a regex engine — djogi's "no Rust
-//! regex" doctrine carries over here even though sassi has no djogi
-//! dependency, because the rule reflects a sound preference for
-//! stdlib primitives.
+//! Case-insensitive string ops use ASCII-only case folding rather than
+//! a regex engine or Unicode locale folding. This keeps in-memory
+//! predicates portable across runtimes and lets downstream SQL emitters
+//! mirror the same contract exactly.
 
 use super::basic::BasicPredicate;
 use super::field_predicate::{FieldPredicate, LookupOp};
 use crate::cacheable::Field;
 use std::any::Any;
 use std::sync::Arc;
+
+fn ascii_fold(value: &str) -> String {
+    value.to_ascii_lowercase()
+}
 
 // === Equality ============================================================
 
@@ -203,6 +206,178 @@ impl<T: 'static, U: Send + Sync + 'static> Field<T, Option<U>> {
     }
 }
 
+/// View of an optional field that only compares the present inner value.
+///
+/// `None` evaluates to `false` for every `PresentField` value comparison.
+pub struct PresentField<T, V> {
+    field: Field<T, Option<V>>,
+}
+
+impl<T, V> std::fmt::Debug for PresentField<T, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PresentField")
+            .field("name", &self.field.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T, V> Copy for PresentField<T, V> {}
+
+impl<T, V> Clone for PresentField<T, V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T, V> Field<T, Option<V>> {
+    /// Compare only the present `Some(V)` value.
+    pub fn some(&self) -> PresentField<T, V> {
+        PresentField { field: *self }
+    }
+}
+
+impl<T: 'static, V: PartialEq + Send + Sync + 'static> PresentField<T, V> {
+    /// `field IS NOT NULL AND field == value`.
+    pub fn eq(&self, val: V) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let val_arc: Arc<V> = Arc::new(val);
+        let val_for_eval = val_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = val_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::Eq,
+            value,
+            move |t| extract(t).as_ref().is_some_and(|v| v == &*val_for_eval),
+        ))
+    }
+
+    /// `field IS NOT NULL AND field != value`.
+    pub fn neq(&self, val: V) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let val_arc: Arc<V> = Arc::new(val);
+        let val_for_eval = val_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = val_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::Neq,
+            value,
+            move |t| extract(t).as_ref().is_some_and(|v| v != &*val_for_eval),
+        ))
+    }
+
+    /// `field IS NOT NULL AND field IN (values...)`.
+    pub fn in_(&self, vals: Vec<V>) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let vec_arc: Arc<Vec<V>> = Arc::new(vals);
+        let vec_for_eval = vec_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = vec_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::In,
+            value,
+            move |t| {
+                extract(t)
+                    .as_ref()
+                    .is_some_and(|v| vec_for_eval.iter().any(|cand| cand == v))
+            },
+        ))
+    }
+
+    /// `field IS NOT NULL AND field NOT IN (values...)`.
+    pub fn not_in(&self, vals: Vec<V>) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let vec_arc: Arc<Vec<V>> = Arc::new(vals);
+        let vec_for_eval = vec_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = vec_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::NotIn,
+            value,
+            move |t| {
+                extract(t)
+                    .as_ref()
+                    .is_some_and(|v| !vec_for_eval.iter().any(|cand| cand == v))
+            },
+        ))
+    }
+}
+
+impl<T: 'static, V: PartialOrd + Send + Sync + 'static> PresentField<T, V> {
+    /// `field IS NOT NULL AND field > value`.
+    pub fn gt(&self, val: V) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let val_arc: Arc<V> = Arc::new(val);
+        let val_for_eval = val_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = val_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::Gt,
+            value,
+            move |t| extract(t).as_ref().is_some_and(|v| v > &*val_for_eval),
+        ))
+    }
+
+    /// `field IS NOT NULL AND field >= value`.
+    pub fn gte(&self, val: V) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let val_arc: Arc<V> = Arc::new(val);
+        let val_for_eval = val_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = val_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::Gte,
+            value,
+            move |t| extract(t).as_ref().is_some_and(|v| v >= &*val_for_eval),
+        ))
+    }
+
+    /// `field IS NOT NULL AND field < value`.
+    pub fn lt(&self, val: V) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let val_arc: Arc<V> = Arc::new(val);
+        let val_for_eval = val_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = val_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::Lt,
+            value,
+            move |t| extract(t).as_ref().is_some_and(|v| v < &*val_for_eval),
+        ))
+    }
+
+    /// `field IS NOT NULL AND field <= value`.
+    pub fn lte(&self, val: V) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let val_arc: Arc<V> = Arc::new(val);
+        let val_for_eval = val_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = val_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::Lte,
+            value,
+            move |t| extract(t).as_ref().is_some_and(|v| v <= &*val_for_eval),
+        ))
+    }
+
+    /// `field IS NOT NULL AND low <= field <= high`.
+    pub fn between(&self, low: V, high: V) -> BasicPredicate<T> {
+        let extract = self.field.extract;
+        let pair_arc: Arc<(V, V)> = Arc::new((low, high));
+        let pair_for_eval = pair_arc.clone();
+        let value: Arc<dyn Any + Send + Sync> = pair_arc;
+        BasicPredicate::Field(FieldPredicate::new(
+            self.field.name,
+            LookupOp::Between,
+            value,
+            move |t| {
+                extract(t)
+                    .as_ref()
+                    .is_some_and(|v| v >= &pair_for_eval.0 && v <= &pair_for_eval.1)
+            },
+        ))
+    }
+}
+
 // === String-specific operations ==========================================
 
 impl<T: 'static> Field<T, String> {
@@ -221,19 +396,19 @@ impl<T: 'static> Field<T, String> {
         ))
     }
 
-    /// Case-insensitive substring match (ASCII-fast-path; UTF-8
-    /// preserved by `to_lowercase`). Operand value layout: `Arc<String>`
+    /// Case-insensitive substring match using ASCII-only folding.
+    /// Operand value layout: `Arc<String>`
     /// — original (non-lowered) needle for inspection.
     pub fn icontains(&self, needle: &str) -> BasicPredicate<T> {
         let extract = self.extract;
         let needle_arc: Arc<String> = Arc::new(needle.to_owned());
-        let needle_lower: String = needle.to_lowercase();
+        let needle_lower = ascii_fold(needle);
         let value: Arc<dyn Any + Send + Sync> = needle_arc;
         BasicPredicate::Field(FieldPredicate::new(
             self.name,
             LookupOp::IContains,
             value,
-            move |t| extract(t).to_lowercase().contains(needle_lower.as_str()),
+            move |t| ascii_fold(extract(t)).contains(needle_lower.as_str()),
         ))
     }
 
@@ -257,13 +432,13 @@ impl<T: 'static> Field<T, String> {
     pub fn istarts_with(&self, prefix: &str) -> BasicPredicate<T> {
         let extract = self.extract;
         let prefix_arc: Arc<String> = Arc::new(prefix.to_owned());
-        let prefix_lower: String = prefix.to_lowercase();
+        let prefix_lower = ascii_fold(prefix);
         let value: Arc<dyn Any + Send + Sync> = prefix_arc;
         BasicPredicate::Field(FieldPredicate::new(
             self.name,
             LookupOp::IStartsWith,
             value,
-            move |t| extract(t).to_lowercase().starts_with(prefix_lower.as_str()),
+            move |t| ascii_fold(extract(t)).starts_with(prefix_lower.as_str()),
         ))
     }
 
@@ -287,36 +462,28 @@ impl<T: 'static> Field<T, String> {
     pub fn iends_with(&self, suffix: &str) -> BasicPredicate<T> {
         let extract = self.extract;
         let suffix_arc: Arc<String> = Arc::new(suffix.to_owned());
-        let suffix_lower: String = suffix.to_lowercase();
+        let suffix_lower = ascii_fold(suffix);
         let value: Arc<dyn Any + Send + Sync> = suffix_arc;
         BasicPredicate::Field(FieldPredicate::new(
             self.name,
             LookupOp::IEndsWith,
             value,
-            move |t| extract(t).to_lowercase().ends_with(suffix_lower.as_str()),
+            move |t| ascii_fold(extract(t)).ends_with(suffix_lower.as_str()),
         ))
     }
 
-    /// `field == value` (case-insensitive ASCII fast-path; falls back
-    /// to full `to_lowercase` for non-ASCII inputs).
+    /// `field == value` using ASCII-only case folding.
     /// Operand value layout: `Arc<String>` — original.
     pub fn iexact(&self, val: &str) -> BasicPredicate<T> {
         let extract = self.extract;
         let val_arc: Arc<String> = Arc::new(val.to_owned());
-        let val_for_eval = val_arc.clone();
+        let val_folded = ascii_fold(val);
         let value: Arc<dyn Any + Send + Sync> = val_arc;
         BasicPredicate::Field(FieldPredicate::new(
             self.name,
             LookupOp::IExact,
             value,
-            move |t| {
-                let extracted = extract(t);
-                if extracted.is_ascii() && val_for_eval.is_ascii() {
-                    extracted.eq_ignore_ascii_case(val_for_eval.as_str())
-                } else {
-                    extracted.to_lowercase() == val_for_eval.to_lowercase()
-                }
-            },
+            move |t| ascii_fold(extract(t)) == val_folded,
         ))
     }
 }

--- a/sassi/src/predicate/memq.rs
+++ b/sassi/src/predicate/memq.rs
@@ -12,7 +12,7 @@
 //! [`BasicPredicate`] tree.
 
 use crate::cacheable::Cacheable;
-use crate::predicate::BasicPredicate;
+use crate::predicate::{BasicPredicate, IntoBasicPredicate};
 use std::any::{Any, TypeId};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
@@ -205,9 +205,12 @@ impl<T: Cacheable> MemQ<T> {
     /// This is the bridge from SQL-projectable
     /// [`BasicPredicate`] into the
     /// Rust-only `MemQ` pipeline.
-    pub fn filter_basic(predicate: BasicPredicate<T>) -> Self {
+    pub fn filter_basic<P>(predicate: P) -> Self
+    where
+        P: IntoBasicPredicate<T>,
+    {
         Self::Filter(Filter {
-            kind: FilterKind::Basic(predicate),
+            kind: FilterKind::Basic(predicate.into_basic_predicate()),
         })
     }
 

--- a/sassi/src/predicate/mod.rs
+++ b/sassi/src/predicate/mod.rs
@@ -17,6 +17,7 @@ pub mod field_ext;
 pub mod field_predicate;
 pub mod memq;
 
-pub use basic::BasicPredicate;
+pub use basic::{BasicPredicate, IntoBasicPredicate};
+pub use field_ext::PresentField;
 pub use field_predicate::{FieldPredicate, LookupOp};
 pub use memq::MemQ;

--- a/sassi/src/punnu/config.rs
+++ b/sassi/src/punnu/config.rs
@@ -59,7 +59,11 @@ pub struct PunnuConfig {
     /// and backend invalidation publishing from
     /// [`crate::punnu::Punnu::invalidate`]. Default
     /// [`BackendFailureMode::L1Only`] — log the error, succeed against
-    /// L1 alone.
+    /// L1 alone. Best-effort single-id invalidation failures also suppress
+    /// local `get_async` L2 rehydration for that id until a later local
+    /// backend write or local backend invalidation succeeds. That suppression
+    /// is per-id and is not capped by `lru_size`, so a prolonged backend outage
+    /// can retain one local suppression entry per failed invalidation.
     pub backend_failure_mode: BackendFailureMode,
 
     /// What to do when [`crate::punnu::Punnu::insert`] is called for an
@@ -145,12 +149,26 @@ impl std::fmt::Debug for PunnuConfig {
 /// Attempt 1 has no preceding delay. Attempt 2 waits 25ms; later
 /// attempts double until capped at 1s. Production retry paths add
 /// jitter on top of this base to avoid synchronized retry storms.
-pub fn retry_delay_for_attempt(attempt_number: u8) -> Duration {
+pub(crate) fn retry_delay_for_attempt(attempt_number: u8) -> Duration {
     if attempt_number <= 1 {
         return Duration::ZERO;
     }
     let exponent = u32::from(attempt_number.saturating_sub(2)).min(10);
     Duration::from_millis((25u64.saturating_mul(1u64 << exponent)).min(1_000))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retry_delay_for_attempt;
+    use std::time::Duration;
+
+    #[test]
+    fn retry_delay_uses_capped_exponential_backoff() {
+        assert_eq!(retry_delay_for_attempt(1), Duration::ZERO);
+        assert_eq!(retry_delay_for_attempt(2), Duration::from_millis(25));
+        assert_eq!(retry_delay_for_attempt(3), Duration::from_millis(50));
+        assert_eq!(retry_delay_for_attempt(8), Duration::from_millis(1_000));
+    }
 }
 
 /// Behaviour when an L2 backend operation fails.
@@ -180,9 +198,9 @@ pub enum BackendFailureMode {
 
     /// Retry the backend operation up to `attempts` total attempts
     /// (including the original call) before falling through to
-    /// L1Only behaviour for retryable errors. Backoff is centrally
-    /// defined by [`retry_delay_for_attempt`] plus 0-25% jitter in
-    /// production call paths. `attempts` must be at least 1.
+    /// L1Only behaviour for retryable errors. Backoff uses an internal
+    /// capped exponential schedule plus 0-25% jitter in production call
+    /// paths. `attempts` must be at least 1.
     Retry {
         /// Number of attempts before giving up.
         attempts: u8,

--- a/sassi/src/punnu/delta_refresh.rs
+++ b/sassi/src/punnu/delta_refresh.rs
@@ -521,6 +521,7 @@ impl<T: DeltaSyncCacheable> RefreshSubscription<T> {
             0
         };
         let (recovery_snapshot, recover_ids) = self.prepare_recovery_query(kind, current_tick);
+        let mut rollback = TickRollbackGuard::new(self, current_tick, recovery_snapshot);
         let since = match kind {
             TickKind::Delta => self
                 .last_watermark
@@ -537,11 +538,11 @@ impl<T: DeltaSyncCacheable> RefreshSubscription<T> {
         let delta = match fetch {
             Ok(Ok(delta)) => delta,
             Ok(Err(err)) => {
-                self.restore_recovery_after_failed(recovery_snapshot, current_tick);
+                rollback.restore_after_failed();
                 return Err(err);
             }
             Err(panic_payload) => {
-                self.restore_recovery_after_failed(recovery_snapshot, current_tick);
+                rollback.restore_after_failed();
                 return Err(FetchError::FetcherPanic {
                     type_name: std::any::type_name::<T>(),
                     message: panic_message(&panic_payload),
@@ -550,15 +551,15 @@ impl<T: DeltaSyncCacheable> RefreshSubscription<T> {
         };
 
         let membership_update =
-            MembershipUpdate::<T::Id>::from_delta(kind, &delta, &recovery_snapshot);
+            MembershipUpdate::<T::Id>::from_delta(kind, &delta, rollback.recovery_snapshot());
         let membership_before_prime = self.membership_snapshot();
         self.prime_membership_for_observed_items(&membership_update);
+        rollback.record_membership_snapshot(membership_before_prime);
         let (applied, next_watermark) =
-            match self.apply_delta_and_observed_watermark(delta, &recovery_snapshot) {
+            match self.apply_delta_and_observed_watermark(delta, rollback.recovery_snapshot()) {
                 Ok(applied) => applied,
                 Err(err) => {
-                    self.restore_membership(membership_before_prime);
-                    self.restore_recovery_after_failed(recovery_snapshot, current_tick);
+                    rollback.restore_after_failed();
                     return Err(err);
                 }
             };
@@ -566,10 +567,7 @@ impl<T: DeltaSyncCacheable> RefreshSubscription<T> {
         let watermark = self.advance_watermark(next_watermark);
         self.note_successful_tick(kind, observed_force_generation);
         self.apply_membership_update(membership_update);
-        self.recovery
-            .lock()
-            .expect("delta refresh recovery lock poisoned")
-            .note_success(recovery_snapshot);
+        rollback.note_success();
 
         Ok(UpdateResult { applied, watermark })
     }
@@ -873,6 +871,92 @@ impl<T: DeltaSyncCacheable> RefreshSubscription<T> {
 
     fn next_operation_id(&self) -> u64 {
         self.next_operation_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+struct TickRollbackGuard<'a, T: DeltaSyncCacheable> {
+    subscription: &'a RefreshSubscription<T>,
+    current_tick: u64,
+    recovery_snapshot: Option<RecoverySnapshot<T::Id>>,
+    membership_before_prime: Option<HashSet<T::Id>>,
+    resolved: bool,
+}
+
+impl<'a, T: DeltaSyncCacheable> TickRollbackGuard<'a, T> {
+    fn new(
+        subscription: &'a RefreshSubscription<T>,
+        current_tick: u64,
+        recovery_snapshot: RecoverySnapshot<T::Id>,
+    ) -> Self {
+        Self {
+            subscription,
+            current_tick,
+            recovery_snapshot: Some(recovery_snapshot),
+            membership_before_prime: None,
+            resolved: false,
+        }
+    }
+
+    fn recovery_snapshot(&self) -> &RecoverySnapshot<T::Id> {
+        self.recovery_snapshot
+            .as_ref()
+            .expect("delta tick recovery snapshot already resolved")
+    }
+
+    fn record_membership_snapshot(&mut self, snapshot: HashSet<T::Id>) {
+        self.membership_before_prime = Some(snapshot);
+    }
+
+    fn restore_after_failed(&mut self) {
+        if let Some(snapshot) = self.membership_before_prime.take() {
+            self.subscription.restore_membership(snapshot);
+        }
+        if let Some(snapshot) = self.recovery_snapshot.take() {
+            self.subscription
+                .restore_recovery_after_failed(snapshot, self.current_tick);
+        }
+        self.resolved = true;
+    }
+
+    fn note_success(mut self) {
+        let Some(snapshot) = self.recovery_snapshot.take() else {
+            self.resolved = true;
+            return;
+        };
+        self.subscription
+            .recovery
+            .lock()
+            .expect("delta refresh recovery lock poisoned")
+            .note_success(snapshot);
+        self.resolved = true;
+    }
+}
+
+impl<T: DeltaSyncCacheable> Drop for TickRollbackGuard<'_, T> {
+    fn drop(&mut self) {
+        if self.resolved {
+            return;
+        }
+
+        if let Some(snapshot) = self.membership_before_prime.take() {
+            match self.subscription.membership.lock() {
+                Ok(mut membership) => *membership = snapshot,
+                Err(_) => tracing::error!(
+                    "delta refresh membership lock poisoned while rolling back failed tick"
+                ),
+            }
+        }
+
+        if let Some(snapshot) = self.recovery_snapshot.take() {
+            match self.subscription.recovery.lock() {
+                Ok(mut recovery) => {
+                    recovery.restore_after_failed(snapshot, self.current_tick);
+                }
+                Err(_) => tracing::error!(
+                    "delta refresh recovery lock poisoned while rolling back failed tick"
+                ),
+            }
+        }
     }
 }
 

--- a/sassi/src/punnu/pool.rs
+++ b/sassi/src/punnu/pool.rs
@@ -189,6 +189,13 @@ pub(crate) struct PunnuInner<T: Cacheable> {
     #[cfg(feature = "serde")]
     backend_strict_insert_released: Notify,
 
+    /// Ids whose L2 backend value is locally untrusted after a best-effort
+    /// invalidation failure. Suppresses `get_async` backend rehydration until a
+    /// later backend write/delete for that id succeeds, independent of L1 LRU
+    /// capacity.
+    #[cfg(feature = "serde")]
+    backend_read_suppressed_ids: Mutex<BTreeSet<T::Id>>,
+
     /// Readiness signal fired on the sweep task's first poll, *before*
     /// the first sleep. Tests `await` this before
     /// `tokio::time::advance(...)` to guarantee the sleep is
@@ -360,12 +367,17 @@ impl<T: Cacheable> Punnu<T> {
                     .put(&keyspace, &id, arc.as_ref(), ttl)
                     .await
                     .map_err(InsertError::BackendFailed)?;
+                self.clear_backend_read_suppression(&id);
                 return self.insert_arc_l1(arc, ttl).await;
             }
 
             let inserted = self.insert_arc_l1(arc.clone(), ttl).await?;
-            self.write_backend_after_l1(backend.as_ref(), &keyspace, &id, arc.as_ref(), ttl)
+            let backend_write_succeeded = self
+                .write_backend_after_l1(backend.as_ref(), &keyspace, &id, arc.as_ref(), ttl)
                 .await;
+            if backend_write_succeeded {
+                self.clear_backend_read_suppression(&id);
+            }
             return Ok(inserted);
         }
 
@@ -437,7 +449,10 @@ impl<T: Cacheable> Punnu<T> {
     /// In the default [`BackendFailureMode::L1Only`] and
     /// [`BackendFailureMode::Retry`] modes, backend invalidation
     /// failures are logged/recorded and the L1 invalidation remains
-    /// successful.
+    /// successful. When that best-effort backend invalidation fails, this
+    /// process suppresses future `get_async` L2 rehydration for the id until a
+    /// later local backend write or local backend invalidation for the same id
+    /// succeeds.
     pub async fn invalidate(
         &self,
         id: &T::Id,
@@ -449,15 +464,22 @@ impl<T: Cacheable> Punnu<T> {
         if self.strict_backend_errors_enabled() {
             let _guard = self.acquire_backend_strict_insert(id).await;
             self.invalidate_backend_strict(id).await?;
+            self.clear_backend_read_suppression(id);
             self.invalidate_l1(id, reason);
             return Ok(());
         }
 
         #[cfg(feature = "serde")]
         let id_for_backend = id.clone();
+        #[cfg(feature = "serde")]
+        if self.inner.backend.is_some() {
+            self.suppress_backend_read(&id_for_backend);
+        }
         self.invalidate_internal(id, reason).await;
         #[cfg(feature = "serde")]
-        self.invalidate_backend_after_l1(&id_for_backend).await;
+        if self.invalidate_backend_after_l1(&id_for_backend).await {
+            self.clear_backend_read_suppression(&id_for_backend);
+        }
         Ok(())
     }
 
@@ -497,7 +519,10 @@ impl<T: Cacheable> Punnu<T> {
     /// Backend hits are validated against the requested canonical id
     /// before they can enter L1. A backend that returns the wrong id is
     /// treated as corrupt data for this key and does not contaminate the
-    /// resident identity map.
+    /// resident identity map. If a prior best-effort invalidation failed for
+    /// this id, the local pool treats the backend value as untrusted and returns
+    /// `Ok(None)` without touching L2 until a later backend write or
+    /// invalidation for the same id succeeds.
     #[cfg(feature = "serde")]
     pub async fn get_async(&self, id: &T::Id) -> Result<Option<Arc<T>>, BackendError> {
         if let Some(arc) = self.get(id) {
@@ -507,6 +532,9 @@ impl<T: Cacheable> Punnu<T> {
         let Some(backend) = &self.inner.backend else {
             return Ok(None);
         };
+        if self.backend_read_suppressed(id) {
+            return Ok(None);
+        }
         let keyspace = self.backend_keyspace();
         let Some(value) = self
             .read_backend_with_policy(backend.as_ref(), &keyspace, id)
@@ -854,7 +882,7 @@ impl<T: Cacheable> Punnu<T> {
     /// Within a single batch call, missing ids are deduplicated
     /// before the batch fetcher is invoked (input may contain dupes).
     /// Across concurrent batch calls, batch-level deduplication is
-    /// **not** implemented in v0.1.0-alpha — two concurrent
+    /// **not** implemented in v0.1.0-beta.1 — two concurrent
     /// `get_or_fetch_many(&[1, 2, 3])` calls invoke the batch fetcher
     /// twice for the same set. Per-id single-flight coalescing across
     /// concurrent *individual* `get_or_fetch` calls still applies as
@@ -2046,26 +2074,30 @@ impl<T: Cacheable> Punnu<T> {
         id: &T::Id,
         value: &T,
         ttl: Option<Duration>,
-    ) {
+    ) -> bool {
         let result = match self.inner.config.backend_failure_mode {
             BackendFailureMode::L1Only => backend.put(keyspace, id, value, ttl).await,
             BackendFailureMode::Retry { attempts } => {
                 self.retry_backend_put(backend, keyspace, id, value, ttl, attempts)
                     .await
             }
-            BackendFailureMode::Error => return,
+            BackendFailureMode::Error => return false,
         };
 
-        if let Err(err) = result {
-            self.log_backend_error(&err);
-            self.metrics_record_backend_error(&err);
+        match result {
+            Ok(()) => true,
+            Err(err) => {
+                self.log_backend_error(&err);
+                self.metrics_record_backend_error(&err);
+                false
+            }
         }
     }
 
     #[cfg(feature = "serde")]
-    async fn invalidate_backend_after_l1(&self, id: &T::Id) {
+    async fn invalidate_backend_after_l1(&self, id: &T::Id) -> bool {
         let Some(backend) = &self.inner.backend else {
-            return;
+            return true;
         };
         let keyspace = self.backend_keyspace();
         let result = match self.inner.config.backend_failure_mode {
@@ -2078,10 +2110,41 @@ impl<T: Cacheable> Punnu<T> {
             }
         };
 
-        if let Err(err) = result {
-            self.log_backend_error(&err);
-            self.metrics_record_backend_error(&err);
+        match result {
+            Ok(()) => true,
+            Err(err) => {
+                self.log_backend_error(&err);
+                self.metrics_record_backend_error(&err);
+                false
+            }
         }
+    }
+
+    #[cfg(feature = "serde")]
+    fn backend_read_suppressed(&self, id: &T::Id) -> bool {
+        self.inner
+            .backend_read_suppressed_ids
+            .lock()
+            .expect("Punnu backend read-suppression table lock poisoned")
+            .contains(id)
+    }
+
+    #[cfg(feature = "serde")]
+    fn suppress_backend_read(&self, id: &T::Id) {
+        self.inner
+            .backend_read_suppressed_ids
+            .lock()
+            .expect("Punnu backend read-suppression table lock poisoned")
+            .insert(id.clone());
+    }
+
+    #[cfg(feature = "serde")]
+    fn clear_backend_read_suppression(&self, id: &T::Id) {
+        self.inner
+            .backend_read_suppressed_ids
+            .lock()
+            .expect("Punnu backend read-suppression table lock poisoned")
+            .remove(id);
     }
 
     #[cfg(feature = "serde")]
@@ -2581,6 +2644,8 @@ impl<T: Cacheable> PunnuBuilder<T> {
             backend_strict_insert_ids: Mutex::new(BTreeSet::new()),
             #[cfg(feature = "serde")]
             backend_strict_insert_released: Notify::new(),
+            #[cfg(feature = "serde")]
+            backend_read_suppressed_ids: Mutex::new(BTreeSet::new()),
             #[cfg(any(
                 all(feature = "runtime-tokio", not(target_arch = "wasm32")),
                 all(feature = "runtime-wasm", target_arch = "wasm32"),

--- a/sassi/src/punnu/scope.rs
+++ b/sassi/src/punnu/scope.rs
@@ -7,7 +7,7 @@
 //! function boundaries without lifetime plumbing.
 
 use crate::cacheable::Cacheable;
-use crate::predicate::{BasicPredicate, MemQ};
+use crate::predicate::{IntoBasicPredicate, MemQ};
 use crate::punnu::Punnu;
 use std::cmp::Ordering;
 use std::hash::Hash;
@@ -63,11 +63,12 @@ impl<T: Cacheable> PunnuScope<T> {
     /// Append a shared field-predicate filter.
     ///
     /// This keeps pure field predicates on the common
-    /// [`BasicPredicate`] path while
+    /// [`BasicPredicate`](crate::predicate::BasicPredicate) path while
     /// still executing in-memory through `MemQ`.
-    pub fn filter_basic<F>(self, build: F) -> Self
+    pub fn filter_basic<F, P>(self, build: F) -> Self
     where
-        F: FnOnce(T::Fields) -> BasicPredicate<T>,
+        F: FnOnce(T::Fields) -> P,
+        P: IntoBasicPredicate<T>,
     {
         self.then(MemQ::filter_basic(build(T::fields())))
     }

--- a/sassi/src/sassi/trait_registry.rs
+++ b/sassi/src/sassi/trait_registry.rs
@@ -32,7 +32,7 @@
 //! the inventory-based registry, and `inventory` documents support for
 //! the wasm32 startup-init slot. Full runtime-test coverage on
 //! `wasm32-unknown-unknown` requires a `wasm-bindgen-test` runner and is
-//! outside the current v0.1.0-alpha release gate.
+//! outside the current v0.1.0-beta.1 release gate.
 
 use crate::sassi::orchestrator::Sassi;
 use std::any::{Any, TypeId};

--- a/sassi/tests/backend_failure_modes.rs
+++ b/sassi/tests/backend_failure_modes.rs
@@ -1,14 +1,13 @@
 #![cfg(all(feature = "serde", feature = "runtime-tokio"))]
 
 use async_trait::async_trait;
-use sassi::punnu::config::retry_delay_for_attempt;
 use sassi::{
     BackendError, BackendFailureMode, BackendInvalidation, BackendKeyspace, CacheBackend,
     Cacheable, DeltaPunnuFetcher, DeltaQuery, DeltaResult, DeltaSyncCacheable, EventReason,
     FetchError, Field, MemoryBackend, Punnu, PunnuConfig, PunnuFetcher, RefreshMode,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -140,14 +139,6 @@ async fn memory_backend_ttl_honors_paused_runtime_clock() {
     tokio::time::advance(Duration::from_secs(6)).await;
 
     assert_eq!(backend.get(&keyspace, &2_i64).await.unwrap(), None::<E>);
-}
-
-#[test]
-fn retry_delay_uses_capped_exponential_backoff() {
-    assert_eq!(retry_delay_for_attempt(1), Duration::ZERO);
-    assert_eq!(retry_delay_for_attempt(2), Duration::from_millis(25));
-    assert_eq!(retry_delay_for_attempt(3), Duration::from_millis(50));
-    assert_eq!(retry_delay_for_attempt(8), Duration::from_millis(1_000));
 }
 
 #[test]
@@ -328,6 +319,218 @@ async fn retry_mode_invalidate_exhaustion_stops_after_total_attempts() {
 
     assert!(punnu.get(&15).is_none());
     assert_eq!(attempts.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn l1only_invalidate_failure_does_not_rehydrate_stale_l2() {
+    let backend = StaleInvalidateBackend::default();
+    let get_attempts = backend.get_attempts.clone();
+    let invalidate_attempts = backend.invalidate_attempts.clone();
+    let punnu = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            backend_failure_mode: BackendFailureMode::L1Only,
+            ..Default::default()
+        })
+        .backend(backend)
+        .build();
+
+    punnu
+        .insert(E {
+            id: 30,
+            label: "stale".into(),
+        })
+        .await
+        .unwrap();
+    punnu
+        .invalidate(&30, sassi::InvalidationReason::OnDelete)
+        .await
+        .unwrap();
+
+    assert!(punnu.get(&30).is_none());
+    assert!(punnu.get_async(&30).await.unwrap().is_none());
+    assert!(punnu.get(&30).is_none());
+    assert_eq!(invalidate_attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(get_attempts.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn retry_invalidate_exhaustion_does_not_rehydrate_stale_l2() {
+    let backend = StaleInvalidateBackend::default();
+    let get_attempts = backend.get_attempts.clone();
+    let invalidate_attempts = backend.invalidate_attempts.clone();
+    let punnu = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            backend_failure_mode: BackendFailureMode::Retry { attempts: 3 },
+            ..Default::default()
+        })
+        .backend(backend)
+        .build();
+
+    punnu
+        .insert(E {
+            id: 31,
+            label: "stale".into(),
+        })
+        .await
+        .unwrap();
+    punnu
+        .invalidate(&31, sassi::InvalidationReason::OnDelete)
+        .await
+        .unwrap();
+
+    assert!(punnu.get(&31).is_none());
+    assert!(punnu.get_async(&31).await.unwrap().is_none());
+    assert!(punnu.get(&31).is_none());
+    assert_eq!(invalidate_attempts.load(Ordering::SeqCst), 3);
+    assert_eq!(get_attempts.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn failed_invalidation_suppression_outlives_lru_capacity() {
+    let backend = StaleInvalidateBackend::default();
+    let get_attempts = backend.get_attempts.clone();
+    let punnu = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            backend_failure_mode: BackendFailureMode::L1Only,
+            lru_size: 1,
+            ..Default::default()
+        })
+        .backend(backend)
+        .build();
+
+    punnu
+        .insert(E {
+            id: 32,
+            label: "first stale".into(),
+        })
+        .await
+        .unwrap();
+    punnu
+        .insert(E {
+            id: 33,
+            label: "second stale".into(),
+        })
+        .await
+        .unwrap();
+
+    assert!(punnu.get(&32).is_none());
+    punnu
+        .invalidate(&32, sassi::InvalidationReason::OnDelete)
+        .await
+        .unwrap();
+    punnu
+        .invalidate(&33, sassi::InvalidationReason::OnDelete)
+        .await
+        .unwrap();
+
+    assert!(punnu.get_async(&32).await.unwrap().is_none());
+    assert!(punnu.get(&32).is_none());
+    assert_eq!(get_attempts.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn concurrent_get_async_does_not_rehydrate_while_invalidate_failure_is_pending() {
+    let backend = BlockingStaleInvalidateBackend::default();
+    let invalidate_entered = backend.invalidate_entered.clone();
+    let invalidate_release = backend.invalidate_release.clone();
+    let get_attempts = backend.get_attempts.clone();
+    let punnu = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            backend_failure_mode: BackendFailureMode::L1Only,
+            ..Default::default()
+        })
+        .backend(backend)
+        .build();
+
+    punnu
+        .insert(E {
+            id: 34,
+            label: "pending stale".into(),
+        })
+        .await
+        .unwrap();
+
+    let invalidating = {
+        let punnu = punnu.clone();
+        tokio::spawn(async move {
+            punnu
+                .invalidate(&34, sassi::InvalidationReason::OnDelete)
+                .await
+        })
+    };
+    tokio::time::timeout(Duration::from_secs(1), invalidate_entered.notified())
+        .await
+        .expect("backend invalidation should be pending");
+
+    let value = punnu.get_async(&34).await.unwrap();
+    invalidate_release.notify_one();
+    invalidating.await.unwrap().unwrap();
+
+    assert!(value.is_none());
+    assert!(punnu.get(&34).is_none());
+    assert_eq!(get_attempts.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn backend_invalidation_stream_does_not_clear_failed_invalidation_suppression() {
+    let (backend, tx) = StreamingStaleInvalidateBackend::new();
+    let get_attempts = backend.get_attempts.clone();
+    let subscribed = backend.subscribed.clone();
+    let punnu = Punnu::<E>::builder()
+        .config(PunnuConfig {
+            backend_failure_mode: BackendFailureMode::L1Only,
+            ..Default::default()
+        })
+        .backend(backend)
+        .build();
+
+    tokio::time::timeout(Duration::from_secs(1), subscribed.notified())
+        .await
+        .expect("listener should subscribe to backend stream");
+
+    punnu
+        .insert(E {
+            id: 35,
+            label: "stale until stream".into(),
+        })
+        .await
+        .unwrap();
+    punnu
+        .invalidate(&35, sassi::InvalidationReason::OnDelete)
+        .await
+        .unwrap();
+
+    assert!(punnu.get_async(&35).await.unwrap().is_none());
+    assert_eq!(get_attempts.load(Ordering::SeqCst), 0);
+
+    let mut events = punnu.events();
+    punnu
+        .get_or_fetch(&35, |id| async move {
+            Ok::<_, FetchError>(Some(E {
+                id,
+                label: "local replacement".into(),
+            }))
+        })
+        .await
+        .unwrap();
+    drain_ready_events(&mut events);
+
+    tx.unbounded_send(Ok(BackendInvalidation::Id(35))).unwrap();
+    let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(matches!(
+        event,
+        sassi::PunnuEvent::Invalidate {
+            id: 35,
+            reason: EventReason::BackendInvalidation { .. }
+        }
+    ));
+    assert!(punnu.get(&35).is_none());
+    assert!(punnu.get_async(&35).await.unwrap().is_none());
+    assert_eq!(get_attempts.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]
@@ -1190,6 +1393,149 @@ impl CacheBackend<E> for RetryInvalidateBackend {
 
     async fn invalidate_all(&self, _keyspace: &BackendKeyspace) -> Result<(), BackendError> {
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct StaleInvalidateBackend {
+    stored: Arc<Mutex<HashMap<i64, E>>>,
+    get_attempts: Arc<AtomicUsize>,
+    invalidate_attempts: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl CacheBackend<E> for StaleInvalidateBackend {
+    async fn get(&self, _keyspace: &BackendKeyspace, id: &i64) -> Result<Option<E>, BackendError> {
+        self.get_attempts.fetch_add(1, Ordering::SeqCst);
+        Ok(self.stored.lock().unwrap().get(id).cloned())
+    }
+
+    async fn put(
+        &self,
+        _keyspace: &BackendKeyspace,
+        id: &i64,
+        value: &E,
+        _ttl: Option<Duration>,
+    ) -> Result<(), BackendError> {
+        self.stored.lock().unwrap().insert(*id, value.clone());
+        Ok(())
+    }
+
+    async fn invalidate(&self, _keyspace: &BackendKeyspace, _id: &i64) -> Result<(), BackendError> {
+        self.invalidate_attempts.fetch_add(1, Ordering::SeqCst);
+        Err(BackendError::Network("stale delete".into()))
+    }
+
+    async fn invalidate_all(&self, _keyspace: &BackendKeyspace) -> Result<(), BackendError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct BlockingStaleInvalidateBackend {
+    stored: Arc<Mutex<HashMap<i64, E>>>,
+    get_attempts: Arc<AtomicUsize>,
+    invalidate_attempts: Arc<AtomicUsize>,
+    invalidate_entered: Arc<Notify>,
+    invalidate_release: Arc<Notify>,
+}
+
+#[async_trait]
+impl CacheBackend<E> for BlockingStaleInvalidateBackend {
+    async fn get(&self, _keyspace: &BackendKeyspace, id: &i64) -> Result<Option<E>, BackendError> {
+        self.get_attempts.fetch_add(1, Ordering::SeqCst);
+        Ok(self.stored.lock().unwrap().get(id).cloned())
+    }
+
+    async fn put(
+        &self,
+        _keyspace: &BackendKeyspace,
+        id: &i64,
+        value: &E,
+        _ttl: Option<Duration>,
+    ) -> Result<(), BackendError> {
+        self.stored.lock().unwrap().insert(*id, value.clone());
+        Ok(())
+    }
+
+    async fn invalidate(&self, _keyspace: &BackendKeyspace, _id: &i64) -> Result<(), BackendError> {
+        self.invalidate_attempts.fetch_add(1, Ordering::SeqCst);
+        self.invalidate_entered.notify_one();
+        self.invalidate_release.notified().await;
+        Err(BackendError::Network("stale delete".into()))
+    }
+
+    async fn invalidate_all(&self, _keyspace: &BackendKeyspace) -> Result<(), BackendError> {
+        Ok(())
+    }
+}
+
+struct StreamingStaleInvalidateBackend {
+    stored: Arc<Mutex<HashMap<i64, E>>>,
+    get_attempts: Arc<AtomicUsize>,
+    invalidate_attempts: Arc<AtomicUsize>,
+    subscribed: Arc<Notify>,
+    rx: Mutex<Option<InvalidationRx>>,
+}
+
+impl StreamingStaleInvalidateBackend {
+    fn new() -> (
+        Self,
+        futures::channel::mpsc::UnboundedSender<Result<BackendInvalidation<i64>, BackendError>>,
+    ) {
+        let (tx, rx) = futures::channel::mpsc::unbounded();
+        (
+            Self {
+                stored: Arc::new(Mutex::new(HashMap::new())),
+                get_attempts: Arc::new(AtomicUsize::new(0)),
+                invalidate_attempts: Arc::new(AtomicUsize::new(0)),
+                subscribed: Arc::new(Notify::new()),
+                rx: Mutex::new(Some(rx)),
+            },
+            tx,
+        )
+    }
+}
+
+#[async_trait]
+impl CacheBackend<E> for StreamingStaleInvalidateBackend {
+    async fn get(&self, _keyspace: &BackendKeyspace, id: &i64) -> Result<Option<E>, BackendError> {
+        self.get_attempts.fetch_add(1, Ordering::SeqCst);
+        Ok(self.stored.lock().unwrap().get(id).cloned())
+    }
+
+    async fn put(
+        &self,
+        _keyspace: &BackendKeyspace,
+        id: &i64,
+        value: &E,
+        _ttl: Option<Duration>,
+    ) -> Result<(), BackendError> {
+        self.stored.lock().unwrap().insert(*id, value.clone());
+        Ok(())
+    }
+
+    async fn invalidate(&self, _keyspace: &BackendKeyspace, _id: &i64) -> Result<(), BackendError> {
+        self.invalidate_attempts.fetch_add(1, Ordering::SeqCst);
+        Err(BackendError::Network("stale delete".into()))
+    }
+
+    async fn invalidate_all(&self, _keyspace: &BackendKeyspace) -> Result<(), BackendError> {
+        Ok(())
+    }
+
+    fn invalidation_stream(
+        &self,
+        _keyspace: BackendKeyspace,
+    ) -> sassi::BackendInvalidationStream<i64> {
+        self.subscribed.notify_one();
+        Box::pin(
+            self.rx
+                .lock()
+                .unwrap()
+                .take()
+                .expect("stream should be subscribed once"),
+        )
     }
 }
 

--- a/sassi/tests/delta_sync_recovery.rs
+++ b/sassi/tests/delta_sync_recovery.rs
@@ -15,13 +15,61 @@ struct Item {
     value: &'static str,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PanicWatermarkItem {
+    id: i64,
+    updated_at: i64,
+    value: &'static str,
+    panic_on_watermark: bool,
+}
+
+#[derive(Default)]
+struct PanicWatermarkFields {
+    #[allow(dead_code)]
+    id: sassi::Field<PanicWatermarkItem, i64>,
+}
+
+impl sassi::Cacheable for PanicWatermarkItem {
+    type Id = i64;
+    type Fields = PanicWatermarkFields;
+
+    fn id(&self) -> Self::Id {
+        self.id
+    }
+
+    fn fields() -> Self::Fields {
+        PanicWatermarkFields {
+            id: sassi::Field::new("id", |item| &item.id),
+        }
+    }
+}
+
+impl sassi::DeltaSyncCacheable for PanicWatermarkItem {
+    type Watermark = i64;
+
+    fn watermark(&self) -> Self::Watermark {
+        assert!(
+            !self.panic_on_watermark,
+            "panic watermark observed after membership priming"
+        );
+        self.updated_at
+    }
+}
+
 type RecordedQuery = (Option<i64>, HashSet<i64>);
+type PanicRecordedQuery = (Option<i64>, HashSet<i64>);
 
 #[derive(Clone)]
 struct RecordingFetcher {
     outcomes: Arc<Mutex<VecDeque<FetchOutcome>>>,
     queries: Arc<Mutex<Vec<RecordedQuery>>>,
     calls: Arc<AtomicUsize>,
+}
+
+#[derive(Clone)]
+struct PanicWatermarkFetcher {
+    outcomes: Arc<Mutex<VecDeque<DeltaResult<PanicWatermarkItem, i64>>>>,
+    queries: Arc<Mutex<Vec<PanicRecordedQuery>>>,
 }
 
 enum FetchOutcome {
@@ -62,6 +110,19 @@ impl RecordingFetcher {
     }
 }
 
+impl PanicWatermarkFetcher {
+    fn new(outcomes: impl Into<VecDeque<DeltaResult<PanicWatermarkItem, i64>>>) -> Self {
+        Self {
+            outcomes: Arc::new(Mutex::new(outcomes.into())),
+            queries: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    async fn queries(&self) -> Vec<PanicRecordedQuery> {
+        self.queries.lock().await.clone()
+    }
+}
+
 #[async_trait::async_trait]
 impl DeltaPunnuFetcher<Item> for RecordingFetcher {
     async fn fetch_delta(
@@ -95,6 +156,25 @@ impl DeltaPunnuFetcher<Item> for RecordingFetcher {
     }
 }
 
+#[async_trait::async_trait]
+impl DeltaPunnuFetcher<PanicWatermarkItem> for PanicWatermarkFetcher {
+    async fn fetch_delta(
+        &self,
+        query: DeltaQuery<PanicWatermarkItem>,
+    ) -> Result<DeltaResult<PanicWatermarkItem, i64>, FetchError> {
+        self.queries
+            .lock()
+            .await
+            .push((query.since, query.recover_ids));
+        Ok(self
+            .outcomes
+            .lock()
+            .await
+            .pop_front()
+            .unwrap_or_else(|| DeltaResult::new(Vec::<PanicWatermarkItem>::new(), HashSet::new())))
+    }
+}
+
 fn item(id: i64, updated_at: i64, value: &'static str) -> Item {
     Item {
         id,
@@ -103,7 +183,25 @@ fn item(id: i64, updated_at: i64, value: &'static str) -> Item {
     }
 }
 
+fn panic_item(
+    id: i64,
+    updated_at: i64,
+    value: &'static str,
+    panic_on_watermark: bool,
+) -> PanicWatermarkItem {
+    PanicWatermarkItem {
+        id,
+        updated_at,
+        value,
+        panic_on_watermark,
+    }
+}
+
 fn delta(items: Vec<Item>) -> DeltaResult<Item, i64> {
+    DeltaResult::new(items, HashSet::new())
+}
+
+fn panic_delta(items: Vec<PanicWatermarkItem>) -> DeltaResult<PanicWatermarkItem, i64> {
     DeltaResult::new(items, HashSet::new())
 }
 
@@ -580,6 +678,66 @@ async fn recovery_set_merges_back_on_fetch_error() {
     assert_eq!(queries.len(), 3);
     assert_eq!(queries[1].1, HashSet::from([1]));
     assert_eq!(queries[2].1, HashSet::from([1]));
+    assert_eq!(punnu.get(&1).unwrap().value, "recovered");
+}
+
+#[tokio::test]
+async fn panic_after_membership_prime_restores_recovery_and_membership() {
+    let punnu = Punnu::<PanicWatermarkItem>::builder()
+        .config(PunnuConfig {
+            lru_size: 1,
+            ..Default::default()
+        })
+        .build();
+    let fetcher = PanicWatermarkFetcher::new([
+        panic_delta(vec![panic_item(1, 10, "seed", false)]),
+        panic_delta(vec![panic_item(2, 20, "panic", true)]),
+        panic_delta(vec![panic_item(1, 30, "recovered", false)]),
+    ]);
+    let handle = punnu
+        .start_delta_refresh(long_interval(), fetcher.clone())
+        .with_eviction_recovery(true);
+
+    handle.update().await.unwrap();
+    punnu
+        .insert(panic_item(99, 99, "evictor", false))
+        .await
+        .unwrap();
+    wait_until(
+        || handle.pending_eviction_recovery_count() == 1,
+        "seed ID should be queued for recovery",
+    )
+    .await;
+
+    let err = handle.update().await.unwrap_err();
+    assert!(matches!(
+        err,
+        FetchError::FetcherPanic {
+            message,
+            ..
+        } if message == "panic watermark observed after membership priming"
+    ));
+
+    punnu
+        .insert(panic_item(2, 21, "local-two", false))
+        .await
+        .unwrap();
+    punnu
+        .insert(panic_item(3, 22, "evict-local-two", false))
+        .await
+        .unwrap();
+
+    handle.update().await.unwrap();
+    handle.cancel();
+
+    let queries = fetcher.queries().await;
+    assert_eq!(queries.len(), 3);
+    assert_eq!(queries[1].1, HashSet::from([1]));
+    assert_eq!(
+        queries[2].1,
+        HashSet::from([1]),
+        "failed tick must not lose recovery ID 1 or subscribe failed item 2"
+    );
     assert_eq!(punnu.get(&1).unwrap().value, "recovered");
 }
 

--- a/sassi/tests/predicate_optional_fields.rs
+++ b/sassi/tests/predicate_optional_fields.rs
@@ -1,0 +1,237 @@
+//! Predicate regressions for optional-field and portable string semantics.
+
+use sassi::{BasicPredicate, Cacheable, Field, IntoBasicPredicate, Punnu};
+
+#[derive(Debug, Clone)]
+struct Artifact {
+    id: i64,
+    title: String,
+    estimated_year: Option<i32>,
+}
+
+#[derive(Default)]
+struct ArtifactFields {
+    #[allow(dead_code)]
+    id: Field<Artifact, i64>,
+    title: Field<Artifact, String>,
+    estimated_year: Field<Artifact, Option<i32>>,
+}
+
+struct NonCloneArtifact {
+    id: i64,
+    estimated_year: Option<i32>,
+}
+
+#[derive(Default)]
+struct NonCloneArtifactFields {
+    estimated_year: Field<NonCloneArtifact, Option<i32>>,
+}
+
+impl Cacheable for NonCloneArtifact {
+    type Id = i64;
+    type Fields = NonCloneArtifactFields;
+
+    fn id(&self) -> i64 {
+        self.id
+    }
+
+    fn fields() -> NonCloneArtifactFields {
+        NonCloneArtifactFields {
+            estimated_year: Field::new("estimated_year", |artifact| &artifact.estimated_year),
+        }
+    }
+}
+
+impl Cacheable for Artifact {
+    type Id = i64;
+    type Fields = ArtifactFields;
+
+    fn id(&self) -> i64 {
+        self.id
+    }
+
+    fn fields() -> ArtifactFields {
+        ArtifactFields {
+            id: Field::new("id", |artifact| &artifact.id),
+            title: Field::new("title", |artifact| &artifact.title),
+            estimated_year: Field::new("estimated_year", |artifact| &artifact.estimated_year),
+        }
+    }
+}
+
+struct WrappedPredicate<T>(BasicPredicate<T>);
+
+impl<T> IntoBasicPredicate<T> for WrappedPredicate<T> {
+    fn into_basic_predicate(self) -> BasicPredicate<T> {
+        self.0
+    }
+}
+
+fn artifact(id: i64, title: &str, estimated_year: Option<i32>) -> Artifact {
+    Artifact {
+        id,
+        title: title.to_owned(),
+        estimated_year,
+    }
+}
+
+#[test]
+fn predicate_optional_fields_some_lte_matches_present_values_only() {
+    let fields = Artifact::fields();
+    let pred = fields.estimated_year.some().lte(2020);
+
+    assert!(pred.evaluate(&artifact(1, "Alpha", Some(2019))));
+    assert!(!pred.evaluate(&artifact(2, "Beta", Some(2021))));
+    assert!(!pred.evaluate(&artifact(3, "Unknown", None)));
+}
+
+#[test]
+fn predicate_optional_fields_basic_predicate_clones_without_model_clone() {
+    let fields = NonCloneArtifact::fields();
+    let pred: BasicPredicate<NonCloneArtifact> = fields.estimated_year.some().lte(2020);
+    let cloned = pred.clone();
+
+    let artifact = NonCloneArtifact {
+        id: 1,
+        estimated_year: Some(2019),
+    };
+
+    assert!(cloned.evaluate(&artifact));
+}
+
+#[test]
+fn predicate_optional_fields_null_and_option_equality_semantics() {
+    let fields = Artifact::fields();
+    let missing = artifact(1, "Unknown", None);
+    let found = artifact(2, "Alpha", Some(2020));
+
+    assert!(fields.estimated_year.is_null().evaluate(&missing));
+    assert!(!fields.estimated_year.is_null().evaluate(&found));
+    assert!(fields.estimated_year.is_not_null().evaluate(&found));
+    assert!(!fields.estimated_year.is_not_null().evaluate(&missing));
+
+    assert!(fields.estimated_year.eq(None).evaluate(&missing));
+    assert!(!fields.estimated_year.eq(None).evaluate(&found));
+    assert!(fields.estimated_year.neq(Some(2020)).evaluate(&missing));
+    assert!(!fields.estimated_year.neq(Some(2020)).evaluate(&found));
+}
+
+#[test]
+fn predicate_optional_fields_some_membership_and_between_reject_none() {
+    let fields = Artifact::fields();
+    let missing = artifact(1, "Unknown", None);
+    let old = artifact(2, "Old", Some(1999));
+    let recent = artifact(3, "Recent", Some(2022));
+
+    assert!(
+        fields
+            .estimated_year
+            .some()
+            .in_(vec![1999, 2020])
+            .evaluate(&old)
+    );
+    assert!(
+        !fields
+            .estimated_year
+            .some()
+            .in_(vec![1999, 2020])
+            .evaluate(&missing)
+    );
+    assert!(
+        fields
+            .estimated_year
+            .some()
+            .not_in(vec![1999, 2020])
+            .evaluate(&recent)
+    );
+    assert!(
+        !fields
+            .estimated_year
+            .some()
+            .not_in(vec![1999, 2020])
+            .evaluate(&missing)
+    );
+    assert!(
+        fields
+            .estimated_year
+            .some()
+            .between(1990, 2000)
+            .evaluate(&old)
+    );
+    assert!(
+        !fields
+            .estimated_year
+            .some()
+            .between(1990, 2000)
+            .evaluate(&missing)
+    );
+}
+
+#[test]
+fn predicate_optional_fields_string_iexact_is_ascii_stable() {
+    let fields = Artifact::fields();
+    let alpha = artifact(1, "Alpha%_\\Trail", Some(2020));
+    let accented_upper = artifact(2, "Éclair", Some(2021));
+    let accented_lower = artifact(3, "éclair", Some(2021));
+
+    assert!(fields.title.iexact("alpha%_\\trail").evaluate(&alpha));
+    assert!(fields.title.iexact("ALPHA%_\\TRAIL").evaluate(&alpha));
+    assert!(!fields.title.iexact("éclair").evaluate(&accented_upper));
+    assert!(!fields.title.iexact("Éclair").evaluate(&accented_lower));
+    assert!(fields.title.iexact("Éclair").evaluate(&accented_upper));
+    assert!(fields.title.iexact("éclair").evaluate(&accented_lower));
+}
+
+#[test]
+fn predicate_optional_fields_string_icontains_is_ascii_stable() {
+    let fields = Artifact::fields();
+    let alpha = artifact(1, "Alpha%_\\Trail", Some(2020));
+    let accented_upper = artifact(2, "Éclair", Some(2021));
+
+    assert!(fields.title.icontains("alpha").evaluate(&alpha));
+    assert!(fields.title.icontains("%_\\").evaluate(&alpha));
+    assert!(fields.title.icontains("A%_\\T").evaluate(&alpha));
+    assert!(!fields.title.icontains("écl").evaluate(&accented_upper));
+    assert!(fields.title.icontains("Écl").evaluate(&accented_upper));
+}
+
+#[test]
+fn predicate_optional_fields_string_istarts_with_is_ascii_stable() {
+    let fields = Artifact::fields();
+    let alpha = artifact(1, "Alpha%_\\Trail", Some(2020));
+    let accented_upper = artifact(2, "Éclair", Some(2021));
+
+    assert!(fields.title.istarts_with("alpha").evaluate(&alpha));
+    assert!(fields.title.istarts_with("alpha%_\\").evaluate(&alpha));
+    assert!(!fields.title.istarts_with("é").evaluate(&accented_upper));
+    assert!(fields.title.istarts_with("É").evaluate(&accented_upper));
+}
+
+#[test]
+fn predicate_optional_fields_string_iends_with_is_ascii_stable() {
+    let fields = Artifact::fields();
+    let alpha = artifact(1, "Alpha%_\\Trail", Some(2020));
+    let accented_upper = artifact(2, "Café", Some(2021));
+
+    assert!(fields.title.iends_with("\\trail").evaluate(&alpha));
+    assert!(fields.title.iends_with("%_\\trail").evaluate(&alpha));
+    assert!(!fields.title.iends_with("FÉ").evaluate(&accented_upper));
+    assert!(fields.title.iends_with("fé").evaluate(&accented_upper));
+}
+
+#[tokio::test]
+async fn predicate_optional_fields_punnu_accepts_into_basic_predicate() {
+    let pool = Punnu::<Artifact>::builder().build();
+    pool.insert(artifact(1, "Old", Some(1999))).await.unwrap();
+    pool.insert(artifact(2, "Recent", Some(2022)))
+        .await
+        .unwrap();
+
+    let results = pool
+        .scope(Vec::new())
+        .filter_basic(|fields| WrappedPredicate(fields.estimated_year.some().lte(2020)))
+        .collect();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, 1);
+}


### PR DESCRIPTION
## Summary
- Bumps Sassi workspace crates/examples to 0.1.0-beta.1 and refreshes release docs, package docs, changelog, and beta readiness notes.
- Adds shared predicate improvements: optional-field present predicates, clone-light BasicPredicate conversion, ASCII-stable case-insensitive string tests, and external field-companion support in sassi-codegen.
- Fixes beta release blockers around retry API privacy, delta-refresh rollback, stale L2 rehydration after failed invalidation, Redis invalidate_all docs, and package/test fixture hygiene.

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked: 302 passed, 1 ignored
- cargo test --workspace --locked: 301 passed, 1 ignored
- cargo test -p sassi --no-default-features --locked: 124 passed
- cargo test -p sassi --no-default-features --features watermark-time --locked: 124 passed
- cargo test -p sassi --no-default-features --features watermark-chrono --locked: 124 passed
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked
- cargo check -p sassi --target wasm32-unknown-unknown --no-default-features --features serde,runtime-wasm,watermark-time,watermark-chrono --locked
- cargo bench -p sassi --bench punnu_bench --features serde,runtime-tokio --locked -- --test
- cargo publish --dry-run -p sassi-codegen --locked --allow-dirty
- Downstream publish dry-runs fail only because 0.1.0-beta.1 upstream crates are not yet on crates.io; package file lists were checked with cargo package --no-verify --list.