### PR TITLE
feat(scope): implement Punnu::scope().filter_impl::<Trait>()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install Rust 1.95 (pinned for lihaaf snapshot stability)
-        uses: dtolnay/rust-toolchain@1.95.0
+        run: rustup toolchain install 1.95.0 --no-self-update --profile minimal
 
       - name: Cache cargo registry and build
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install Rust 1.95 (pinned for lihaaf snapshot stability)
-        run: rustup toolchain install 1.95.0 --no-self-update --profile minimal
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo registry and build
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Install Rust 1.95 (pinned for lihaaf snapshot stability)
+        uses: dtolnay/rust-toolchain@1.95.0
+
       - name: Cache cargo registry and build
         uses: actions/cache@v5
         with:
@@ -68,7 +71,7 @@ jobs:
         run: cargo install lihaaf --version 0.1.0-beta.10 --locked
 
       - name: Lihaaf compile-fixture suite (sassi-macros)
-        run: cargo lihaaf --manifest-path sassi-macros/Cargo.toml
+        run: cargo +1.95.0 lihaaf --manifest-path sassi-macros/Cargo.toml
 
   wasm-target:
     name: WASM target build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,11 @@ jobs:
         run: cargo test -p sassi --no-default-features --features "serde,runtime-tokio"
 
       # Lihaaf is the authoritative compile-fixture gate for sassi.
-      # Pinned to an exact beta to keep the snapshot byte format and
+      # Pinned to an exact version to keep the snapshot byte format and
       # CLI surface deterministic across runs; bumping the pin is a
       # conscious step that travels with any required `--bless`.
-      - name: Install cargo-lihaaf (pinned beta)
-        run: cargo install lihaaf --version 0.1.0-beta.10 --locked
+      - name: Install cargo-lihaaf (pinned)
+        run: cargo install lihaaf --version 0.2.0 --locked
 
       - name: Lihaaf compile-fixture suite (sassi-macros)
         run: cargo lihaaf --manifest-path sassi-macros/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Install Rust 1.95 (pinned for lihaaf snapshot stability)
-        uses: dtolnay/rust-toolchain@1.95.0
-
       - name: Cache cargo registry and build
         uses: actions/cache@v5
         with:
@@ -71,7 +68,7 @@ jobs:
         run: cargo install lihaaf --version 0.1.0-beta.10 --locked
 
       - name: Lihaaf compile-fixture suite (sassi-macros)
-        run: cargo +1.95.0 lihaaf --manifest-path sassi-macros/Cargo.toml
+        run: cargo lihaaf --manifest-path sassi-macros/Cargo.toml
 
   wasm-target:
     name: WASM target build and test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,7 @@
   page now leads with the "typed cache substrate" framing, includes a
   derive-based Quick Tour example wrapped in `async fn run()`, and
   documents the `Cacheable` derive's requirement that the struct carry a
-  field literally named `id` (with a note that v0.2 will introduce
-  `#[cacheable(id)]` for structs whose identifier field has a
-  different name).
+  field literally named `id`.
 - Refreshed the `sassi` crate metadata to match the README's "cache
   substrate" framing: rewrote `description` from "Typed in-memory pool
   with composable predicate algebra and cross-runtime trait queries." to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- `cargo-lihaaf` dev-tool pin bumped `0.1.0-beta.9` → `0.1.0-beta.10` in
+- `cargo-lihaaf` dev-tool pin bumped `0.1.0-beta.9` → `0.2.0` in
   `.github/workflows/ci.yml`, `sassi-macros/Cargo.toml`, and
   `docs/release-readiness.md`. Local fixture canary on `sassi-macros`
   (30/30 OK) confirmed before the pin change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- `PunnuScope::filter_impl::<Trait>()` — single-type, compile-time trait-narrowed scope filter. Gated on new `TraitImpl<Trait>` marker emitted by `#[sassi::trait_impl]`.
+- `TraitImpl<Trait>` public marker trait (zero runtime cost).
+
 ### Changed
 
 - `cargo-lihaaf` dev-tool pin bumped `0.1.0-beta.9` → `0.1.0-beta.10` in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bardownski"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "clap",
  "crossterm",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "sassi"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "sassi-cache-redis"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "sassi-codegen"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "sassi-macros"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/TarunvirBains/sassi"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ async fn main() {
 
 The `#[derive(Cacheable)]` macro requires a field literally named `id`. Types
 whose identifier uses a different name (e.g. `user_id`) need a hand-written
-`Cacheable` impl until v0.2 adds `#[cacheable(id)]`.
+`Cacheable` impl.
 
 ## Concepts
 
@@ -81,7 +81,7 @@ whose identifier uses a different name (e.g. `user_id`) need a hand-written
 
 ## Cache Lifecycle Features
 
-- **Fetch-on-miss and coalescing**: `get_or_fetch` collapses concurrent fetches for the same id into a single execution. `get_or_fetch_many` deduplicates ids within a single batch call; concurrent batch calls for the same ids are not cross-coalesced in v0.1.0-beta.4.
+- **Fetch-on-miss and coalescing**: `get_or_fetch` collapses concurrent fetches for the same id into a single execution. `get_or_fetch_many` deduplicates ids within a single batch call; concurrent batch calls for the same ids are not presently cross-coalesced.
 - **Bounded Eviction**: Sampled-LRU eviction and optional TTL keep your memory footprint bounded. TTL cleanup is lazy by default — expired entries are observed as misses by `get` and reclaimed under capacity pressure; configure `ttl_sweep_interval` to opt into a background sweep task.
 - **Refresh**: Built-in mechanisms for periodic polling and watermark-based delta sync drive background updates. Eviction recovery (re-fetching entries that LRU pressure dropped) is opt-in via `DeltaRefreshHandle::with_eviction_recovery(true)`.
 - **Events**: Subscribe to streams of inserts, updates, and deletes to trigger application UI renders or downstream side effects. Events are best-effort observability with a lossy contract — slow subscribers and missing subscribers drop events — not a durable log; build durable side-effect pipelines on the source of truth instead.

--- a/docs/backends-and-runtimes.md
+++ b/docs/backends-and-runtimes.md
@@ -58,11 +58,9 @@ that want to claim a cache entry is portable over Sassi's existing wire. Add
 and read the same bytes as `to_vec` / `from_slice`; they only require the entry
 to implement `WirePortable`.
 
-Backend and snapshot APIs keep their current loose serde bounds in this
-release. `MemoryBackend`, `FileBackend`, `Punnu::insert_serialized`, entries
+Backend and snapshot APIs keep their current loose serde bounds. `MemoryBackend`, `FileBackend`, `Punnu::insert_serialized`, entries
 export/restore, and whole-pool snapshot/restore do not require
-`WirePortable`. A future release may ratchet backend bounds, but this release
-only adds the strict helper path.
+`WirePortable`.
 
 Rejected JSON-like fields should be projected to portable cache fields. Use
 `JSahibON` when the cache needs raw JSON and local JSON predicates, a typed
@@ -207,11 +205,6 @@ caller. Operators using shared Redis should clear the keyspace or roll
 `PunnuConfig::namespace` during upgrade so beta.2 readers do not attempt to
 decode beta.1 JSON values.
 
-The final commit where the beta.1 JSON value envelope was live is
-`92b77510cb80d98fd749020df3d18571200a315f`; use
-`git show 92b77510cb80d98fd749020df3d18571200a315f:sassi/src/wire.rs` if an
-upgrade tool needs the exact historical decoder.
-
 ## Local Snapshots vs Shared Backend Mutation
 
 Sassi supports two cache surfaces concurrently: shared L2 mutation through
@@ -250,8 +243,7 @@ local_store.save("proposal-cache", bytes).await?;
 Here, "strict" means an active backend write reservation from a pool using
 `BackendFailureMode::Error`; this is a race guard, not an enforcement mechanism
 for the broader rule above. The intended restore path is backend-less local
-hydration; backend seeding remains a future async API rather than a widening of
-`restore_entries_postcard`.
+hydration; `restore_entries_postcard` is presently L1-only.
 
 The snapshot is not a distributed correctness boundary. Applications that need
 multi-device or service-to-service recovery should pair entries snapshots with

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -105,7 +105,7 @@ callers can inspect field names, lookup operators, and typed operand values.
 That makes it a useful bridge between a data-layer fetcher and Sassi's
 in-memory replay.
 
-It is not a serde wire format in v0.1.0. Persisting or transmitting predicate
+It is not presently a serde wire format. Persisting or transmitting predicate
 values across processes needs an application or downstream crate to define a
 typed codec.
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -178,7 +178,7 @@ under `sassi-macros/tests/lihaaf/`. It replaces the earlier `trybuild`-driven
 fixtures and is now the authoritative gate for proc-macro derive errors,
 `#[sassi::trait_impl]` attribute expansions, and `MonotonicWatermark`
 trait-bound rejections. Install once locally with
-`cargo install lihaaf --version 0.1.0-beta.10 --locked`; CI installs it
+`cargo install lihaaf --version 0.2.0 --locked`; CI installs it
 through the same pin. To re-bless snapshots after an intentional diagnostic
 change, run `cargo lihaaf --manifest-path sassi-macros/Cargo.toml --bless`
 and review the resulting `.stderr` diff before committing.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -5,7 +5,7 @@ willing to work with an early but candidate API surface. The goal is not to
 claim that every future integration is done; it is to make the current
 contracts, tradeoffs, and verification expectations visible before publish.
 
-## v0.1.0-beta.4 Scope
+## Scope
 
 In scope for the beta:
 
@@ -94,14 +94,10 @@ These are intentionally not release claims for v0.1.0-beta.4:
   Applications re-attach refresh handles after restore and resume from a
   consumer-persisted watermark.
 - A backend-seeding restore. `restore_entries_postcard` and `restore_postcard`
-  are L1-only; a future backend-seeding restore, if needed, would be a
-  separate async API.
+  are presently L1-only.
 - Certified framework adapters.
 - Automatic cross-process coherence for Redis `put`/`insert` writes without
   explicit invalidation publication.
-
-Those deferrals are not dismissals. They are places where Sassi needs real
-integration pressure before it should freeze an abstraction.
 
 ## Documentation Invariants
 
@@ -192,15 +188,6 @@ the upstream crate exists on crates.io. Publish or dry-run in dependency order:
 `sassi-codegen`, then `sassi-macros`, then `sassi`, then `sassi-cache-redis`.
 After each upstream publish is visible in the registry index, rerun the next
 dry-run cleanly before publishing it.
-
-The repository README uses version-tagged GitHub documentation links for the
-crate landing page, including the link to `CONTRIBUTING.md`. Workflow and
-contributor-process docs evolve between releases; pinning the README's links
-to the release tag gives adopters reading the published package a snapshot of
-those docs as of the release, with the current state always one click away
-through GitHub's branch navigation. Keep the release commit, crates.io publish,
-`v0.1.0-beta.4` tag, and GitHub release aligned so those links resolve for
-adopters reading the published package.
 
 Benchmark documentation lives in
 [sassi/benches/README.md](../sassi/benches/README.md). The current expectation

--- a/examples/bardownski/README.md
+++ b/examples/bardownski/README.md
@@ -18,6 +18,4 @@ For a non-interactive smoke test:
 cargo run -p bardownski -- --summary --on-rebound
 ```
 
-A future Dioxus/full-stack version of Bardownski is planned outside this
-repository. This in-repo example is intentionally native-only: no WASM, no
-Redis, and no Dioxus.
+This in-repo example is intentionally native-only: no WASM, no Redis, and no Dioxus.

--- a/sassi-macros/Cargo.toml
+++ b/sassi-macros/Cargo.toml
@@ -32,13 +32,13 @@ sassi-codegen = { path = "../sassi-codegen", version = "0.1.0-beta.5" }
 # proc-macros through `sassi`'s `pub use sassi_macros::*` re-export.
 sassi = { path = "../sassi" }
 
-# Lihaaf — Phase 8.5 replacement for trybuild. See the
+# cargo-lihaaf — compile-fixture gate (trybuild replacement). See the
 # `[package.metadata.lihaaf]` block below for fixture-suite
 # configuration. lihaaf ships as the `cargo-lihaaf` binary (cargo
 # subcommand), not a library dep; adopters subprocess-spawn `cargo
 # lihaaf` instead of importing `lihaaf::*`. CI installs the
 # `cargo-lihaaf` binary explicitly; local contributors should `cargo
-# install lihaaf --version 0.1.0-beta.10` (or run from a checkout of
+# install lihaaf --version 0.2.0` (or run from a checkout of
 # the sibling repo).
 #
 # Fixture layout (`tests/lihaaf/{compile_fail,compile_pass}/`) follows

--- a/sassi-macros/Cargo.toml
+++ b/sassi-macros/Cargo.toml
@@ -20,7 +20,7 @@ proc-macro2 = { workspace = true }
 proc-macro-crate = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
-sassi-codegen = { path = "../sassi-codegen", version = "0.1.0-beta.4" }
+sassi-codegen = { path = "../sassi-codegen", version = "0.1.0-beta.5" }
 
 [dev-dependencies]
 # `sassi` as a dev-dep forms a cycle (`sassi` regularly depends on

--- a/sassi-macros/src/trait_impl.rs
+++ b/sassi-macros/src/trait_impl.rs
@@ -23,7 +23,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{ItemImpl, parse_macro_input, spanned::Spanned};
+use syn::spanned::Spanned;
 
 use crate::sassi_path;
 
@@ -47,13 +47,18 @@ use crate::sassi_path;
 ///   has no captured lifetimes; in practice almost every cross-type
 ///   trait satisfies this naturally.
 pub fn trait_impl(args: TokenStream, input: TokenStream) -> TokenStream {
-    let args = TokenStream2::from(args);
-    let item = parse_macro_input!(input as ItemImpl);
+    trait_impl_impl(args.into(), input.into()).into()
+}
+
+fn trait_impl_impl(args: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let item = match syn::parse2::<syn::ItemImpl>(input) {
+        Ok(item) => item,
+        Err(e) => return e.to_compile_error(),
+    };
 
     if !args.is_empty() {
         return syn::Error::new(args.span(), "sassi::trait_impl takes no arguments")
-            .to_compile_error()
-            .into();
+            .to_compile_error();
     }
 
     if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
@@ -61,8 +66,7 @@ pub fn trait_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             item.generics.span(),
             "#[sassi::trait_impl] currently supports concrete, non-generic impl blocks",
         )
-        .to_compile_error()
-        .into();
+        .to_compile_error();
     }
 
     let trait_path = match &item.trait_ {
@@ -72,27 +76,27 @@ pub fn trait_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 not_token.span(),
                 "#[sassi::trait_impl] cannot register negative impl blocks",
             )
-            .to_compile_error()
-            .into();
+            .to_compile_error();
         }
         None => {
             return syn::Error::new(
                 item.impl_token.span(),
                 "sassi::trait_impl must be applied to `impl Trait for Type`",
             )
-            .to_compile_error()
-            .into();
+            .to_compile_error();
         }
     };
 
     let sassi_path = match sassi_path() {
         Ok(path) => path,
-        Err(e) => return e.to_compile_error().into(),
+        Err(e) => return e.to_compile_error(),
     };
 
     let model_ty = &item.self_ty;
     let expanded = quote! {
         #item
+
+        impl #sassi_path::TraitImpl<dyn #trait_path> for #model_ty {}
 
         const _: () = {
             fn __sassi_collect_trait_impl(
@@ -121,5 +125,27 @@ pub fn trait_impl(args: TokenStream, input: TokenStream) -> TokenStream {
         };
     };
 
-    expanded.into()
+    expanded
+}
+
+#[cfg(test)]
+mod marker_emit_tests {
+    use super::trait_impl_impl;
+    use quote::quote;
+
+    #[test]
+    fn emits_marker_impl_for_dyn_trait() {
+        let item = quote! {
+            impl Searchable for Vehicle {
+                fn cols(&self) -> &'static [&'static str] { &["title"] }
+            }
+        };
+        let out = trait_impl_impl(quote! {}, item).to_string();
+        assert!(out.contains("impl Searchable for Vehicle"));
+        assert!(
+            out.contains("TraitImpl") && out.contains("for Vehicle"),
+            "expected a TraitImpl<dyn Searchable> impl for Vehicle; got: {out}"
+        );
+        assert!(out.contains("TraitImplEntry"));
+    }
 }

--- a/sassi-macros/src/trait_impl.rs
+++ b/sassi-macros/src/trait_impl.rs
@@ -96,6 +96,7 @@ fn trait_impl_impl(args: TokenStream2, input: TokenStream2) -> TokenStream2 {
     let expanded = quote! {
         #item
 
+        impl #sassi_path::__private::Sealed<dyn #trait_path> for #model_ty {}
         impl #sassi_path::TraitImpl<dyn #trait_path> for #model_ty {}
 
         const _: () = {
@@ -145,6 +146,10 @@ mod marker_emit_tests {
         assert!(
             out.contains("TraitImpl") && out.contains("for Vehicle"),
             "expected a TraitImpl<dyn Searchable> impl for Vehicle; got: {out}"
+        );
+        assert!(
+            out.contains("Sealed") && out.contains("for Vehicle"),
+            "expected a Sealed<dyn Searchable> witness impl for Vehicle; got: {out}"
         );
         assert!(out.contains("TraitImplEntry"));
     }

--- a/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.rs
+++ b/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.rs
@@ -1,0 +1,20 @@
+use sassi::{Cacheable, MemQ, Punnu, punnu::PunnuScope};
+
+trait IsVehicle: Send + Sync {}
+
+#[derive(Clone)]
+struct Car { id: u32 }
+
+#[derive(Default)]
+struct EmptyFields;
+
+impl Cacheable for Car {
+    type Id = u32;
+    type Fields = EmptyFields;
+    fn id(&self) -> u32 { self.id }
+    fn fields() -> EmptyFields { EmptyFields }
+}
+
+fn check(scope: PunnuScope<Car>) {
+    let _ = scope.filter_impl::<dyn IsVehicle>();
+}

--- a/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.rs
+++ b/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.rs
@@ -1,4 +1,4 @@
-use sassi::{Cacheable, MemQ, Punnu, punnu::PunnuScope};
+use sassi::{Cacheable, punnu::PunnuScope};
 
 trait IsVehicle: Send + Sync {}
 

--- a/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.rs
+++ b/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.rs
@@ -18,3 +18,5 @@ impl Cacheable for Car {
 fn check(scope: PunnuScope<Car>) {
     let _ = scope.filter_impl::<dyn IsVehicle>();
 }
+
+fn main() {}

--- a/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.stderr
@@ -5,25 +5,25 @@ error[E0601]: `main` function not found in crate `filter_impl_requires_marker`
    |  ^ consider adding a `main` function to `$DIR/filter_impl_requires_marker.rs`
 
 error[E0277]: `Car` is not registered as an implementation of `dyn IsVehicle`
-  --> $DIR/filter_impl_requires_marker.rs:19:19
-   |
-19 |     let _ = scope.filter_impl::<dyn IsVehicle>();
-   |                   ^^^^^^^^^^^ unsatisfied trait bound
-   |
+   --> $DIR/filter_impl_requires_marker.rs:19:19
+    |
+ 19 |     let _ = scope.filter_impl::<dyn IsVehicle>();
+    |                   ^^^^^^^^^^^ unsatisfied trait bound
+    |
 help: the trait `sassi::TraitImpl<dyn IsVehicle>` is not implemented for `Car`
-  --> $DIR/filter_impl_requires_marker.rs:6:1
-   |
- 6 | struct Car { id: u32 }
-   | ^^^^^^^^^^
-   = note: apply `#[sassi::trait_impl]` to the `impl dyn IsVehicle for Car` block
+   --> $DIR/filter_impl_requires_marker.rs:6:1
+    |
+  6 | struct Car { id: u32 }
+    | ^^^^^^^^^^
+    = note: apply `#[sassi::trait_impl]` to the `impl dyn IsVehicle for Car` block
 note: required by a bound in `PunnuScope::<T>::filter_impl`
-  --> sassi/src/punnu/scope.rs:99:12
-   |
-96 |     pub fn filter_impl<Trait>(self) -> Self
-   |            ----------- required by a bound in this associated function
+   --> sassi/src/punnu/scope.rs:147:12
+    |
+144 |     pub fn filter_impl<Trait>(self) -> Self
+    |            ----------- required by a bound in this associated function
 ...
-99 |         T: TraitImpl<Trait>,
-   |            ^^^^^^^^^^^^^^^^ required by this bound in `PunnuScope::<T>::filter_impl`
+147 |         T: TraitImpl<Trait>,
+    |            ^^^^^^^^^^^^^^^^ required by this bound in `PunnuScope::<T>::filter_impl`
 
 error: aborting due to 2 previous errors
 

--- a/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.stderr
@@ -1,0 +1,39 @@
+warning: unused imports: `MemQ` and `Punnu`
+ --> $DIR/filter_impl_requires_marker.rs:1:24
+  |
+1 | use sassi::{Cacheable, MemQ, Punnu, punnu::PunnuScope};
+  |                        ^^^^  ^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+error[E0601]: `main` function not found in crate `filter_impl_requires_marker`
+  --> $DIR/filter_impl_requires_marker.rs:20:2
+   |
+20 | }
+   |  ^ consider adding a `main` function to `$DIR/filter_impl_requires_marker.rs`
+
+error[E0277]: `Car` is not registered as an implementation of `dyn IsVehicle`
+  --> $DIR/filter_impl_requires_marker.rs:19:19
+   |
+19 |     let _ = scope.filter_impl::<dyn IsVehicle>();
+   |                   ^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `sassi::TraitImpl<dyn IsVehicle>` is not implemented for `Car`
+  --> $DIR/filter_impl_requires_marker.rs:6:1
+   |
+ 6 | struct Car { id: u32 }
+   | ^^^^^^^^^^
+   = note: apply `#[sassi::trait_impl]` to the `impl dyn IsVehicle for Car` block
+note: required by a bound in `PunnuScope::<T>::filter_impl`
+  --> sassi/src/punnu/scope.rs:99:12
+   |
+96 |     pub fn filter_impl<Trait>(self) -> Self
+   |            ----------- required by a bound in this associated function
+...
+99 |         T: TraitImpl<Trait>,
+   |            ^^^^^^^^^^^^^^^^ required by this bound in `PunnuScope::<T>::filter_impl`
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0277, E0601.
+For more information about an error, try `rustc --explain E0277`.

--- a/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.stderr
@@ -1,11 +1,3 @@
-warning: unused imports: `MemQ` and `Punnu`
- --> $DIR/filter_impl_requires_marker.rs:1:24
-  |
-1 | use sassi::{Cacheable, MemQ, Punnu, punnu::PunnuScope};
-  |                        ^^^^  ^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
-
 error[E0601]: `main` function not found in crate `filter_impl_requires_marker`
   --> $DIR/filter_impl_requires_marker.rs:20:2
    |
@@ -33,7 +25,7 @@ note: required by a bound in `PunnuScope::<T>::filter_impl`
 99 |         T: TraitImpl<Trait>,
    |            ^^^^^^^^^^^^^^^^ required by this bound in `PunnuScope::<T>::filter_impl`
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0277, E0601.
 For more information about an error, try `rustc --explain E0277`.

--- a/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/filter_impl_requires_marker.stderr
@@ -1,9 +1,3 @@
-error[E0601]: `main` function not found in crate `filter_impl_requires_marker`
-  --> $DIR/filter_impl_requires_marker.rs:20:2
-   |
-20 | }
-   |  ^ consider adding a `main` function to `$DIR/filter_impl_requires_marker.rs`
-
 error[E0277]: `Car` is not registered as an implementation of `dyn IsVehicle`
    --> $DIR/filter_impl_requires_marker.rs:19:19
     |
@@ -25,7 +19,6 @@ note: required by a bound in `PunnuScope::<T>::filter_impl`
 147 |         T: TraitImpl<Trait>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `PunnuScope::<T>::filter_impl`
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0277, E0601.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0277`.

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_marker_handwritten.rs
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_marker_handwritten.rs
@@ -1,0 +1,38 @@
+// compile_fail: the TraitImpl marker has a sealed supertrait. A plain
+// hand-written `impl TraitImpl<dyn Trait> for Type {}` is rejected at
+// compile time, so a type that skips `#[sassi::trait_impl]` cannot be
+// passed to filter_impl. (Reaching into #[doc(hidden)] sassi::__private
+// to forge the supertrait by hand is possible but warranty-voiding.)
+
+use sassi::{Cacheable, TraitImpl, punnu::PunnuScope};
+
+trait IsVehicle: Send + Sync {}
+
+#[derive(Clone)]
+struct Car {
+    id: u32,
+}
+
+#[derive(Default)]
+struct EmptyFields;
+
+impl Cacheable for Car {
+    type Id = u32;
+    type Fields = EmptyFields;
+    fn id(&self) -> u32 {
+        self.id
+    }
+    fn fields() -> EmptyFields {
+        EmptyFields
+    }
+}
+
+// Forged registration: no #[sassi::trait_impl] anywhere. This impl must be
+// rejected because TraitImpl's sealed supertrait is unreachable here.
+impl TraitImpl<dyn IsVehicle> for Car {}
+
+fn uses_it(scope: PunnuScope<Car>) {
+    let _ = scope.filter_impl::<dyn IsVehicle>();
+}
+
+fn main() {}

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_marker_handwritten.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_marker_handwritten.stderr
@@ -1,19 +1,19 @@
 error[E0277]: the trait bound `Car: sassi::__private::Sealed<(dyn IsVehicle + 'static)>` is not satisfied
-  --> $DIR/trait_impl_marker_handwritten.rs:32:35
-   |
-32 | impl TraitImpl<dyn IsVehicle> for Car {}
-   |                                   ^^^ unsatisfied trait bound
-   |
+   --> $DIR/trait_impl_marker_handwritten.rs:32:35
+    |
+ 32 | impl TraitImpl<dyn IsVehicle> for Car {}
+    |                                   ^^^ unsatisfied trait bound
+    |
 help: the trait `sassi::__private::Sealed<(dyn IsVehicle + 'static)>` is not implemented for `Car`
-  --> $DIR/trait_impl_marker_handwritten.rs:12:1
-   |
-12 | struct Car {
-   | ^^^^^^^^^^
+   --> $DIR/trait_impl_marker_handwritten.rs:12:1
+    |
+ 12 | struct Car {
+    | ^^^^^^^^^^
 note: required by a bound in `sassi::TraitImpl`
-  --> sassi/src/sassi/trait_registry.rs:94:37
-   |
-94 | pub trait TraitImpl<Trait: ?Sized>: __sealed::Sealed<Trait> {}
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `TraitImpl`
+   --> sassi/src/sassi/trait_registry.rs:121:37
+    |
+121 | pub trait TraitImpl<Trait: ?Sized>: __sealed::Sealed<Trait> {}
+    |                                     ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `TraitImpl`
 
 error: aborting due to 1 previous error
 

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_marker_handwritten.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_marker_handwritten.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the trait bound `Car: sassi::__private::Sealed<(dyn IsVehicle + 'static)>` is not satisfied
+  --> $DIR/trait_impl_marker_handwritten.rs:32:35
+   |
+32 | impl TraitImpl<dyn IsVehicle> for Car {}
+   |                                   ^^^ unsatisfied trait bound
+   |
+help: the trait `sassi::__private::Sealed<(dyn IsVehicle + 'static)>` is not implemented for `Car`
+  --> $DIR/trait_impl_marker_handwritten.rs:12:1
+   |
+12 | struct Car {
+   | ^^^^^^^^^^
+note: required by a bound in `sassi::TraitImpl`
+  --> sassi/src/sassi/trait_registry.rs:94:37
+   |
+94 | pub trait TraitImpl<Trait: ?Sized>: __sealed::Sealed<Trait> {}
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `TraitImpl`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.rs
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.rs
@@ -1,0 +1,10 @@
+extern crate std;
+
+#[sassi::trait_impl]
+impl std::fmt::Display for std::vec::Vec<i32> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "vec")
+    }
+}
+
+fn main() {}

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.rs
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.rs
@@ -1,13 +1,9 @@
-// compile_fail: orphan rule enforcement.
-// #[sassi::trait_impl] inherits this constraint: if you can't write
-// `impl ForeignTrait for ForeignType`, you certainly can't annotate
-// it with #[sassi::trait_impl]. The marker impl emitted by the macro
-// adds no new orphan-rule restriction beyond what the original impl
-// already requires.
+extern crate std;
 
-impl std::fmt::Display for String {
+#[sassi::trait_impl]
+impl std::fmt::Display for std::vec::Vec<i32> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "vec")
     }
 }
 

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.rs
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.rs
@@ -1,9 +1,13 @@
-extern crate std;
+// compile_fail: orphan rule enforcement.
+// #[sassi::trait_impl] inherits this constraint: if you can't write
+// `impl ForeignTrait for ForeignType`, you certainly can't annotate
+// it with #[sassi::trait_impl]. The marker impl emitted by the macro
+// adds no new orphan-rule restriction beyond what the original impl
+// already requires.
 
-#[sassi::trait_impl]
-impl std::fmt::Display for std::vec::Vec<i32> {
+impl std::fmt::Display for String {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "vec")
+        write!(f, "{}", self)
     }
 }
 

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
@@ -46,11 +46,10 @@ error[E0599]: the method `scope` exists for struct `Arc<Punnu<Vec<i32>>>`, but i
   3 | #[sassi::trait_impl]
     | ^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Arc<Punnu<Vec<i32>>>` due to unsatisfied trait bounds
     |
-   ::: $RUST/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:438:1
-    |
-438 | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
-    | ------------------------------------------------------------------------------------------------ doesn't satisfy `Vec<i32>: Cacheable`
-    |
+   ::: $RUST/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs
+   |
+   | $RUST_SRC
+   |
     = note: the following trait bounds were not satisfied:
             `Vec<i32>: Cacheable`
     = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
@@ -1,56 +1,15 @@
 error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
- --> $DIR/trait_impl_orphan_violation.rs:4:1
+ --> $DIR/trait_impl_orphan_violation.rs:8:1
   |
-4 | impl std::fmt::Display for std::vec::Vec<i32> {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------
+8 | impl std::fmt::Display for String {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^------
   |                            |
-  |                            `Vec` is not defined in the current crate
+  |                            `String` is not defined in the current crate
   |
   = note: impl doesn't have any local type before any uncovered type parameters
   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
   = note: define and implement a trait or new type instead
 
-error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
- --> $DIR/trait_impl_orphan_violation.rs:3:1
-  |
-3 | #[sassi::trait_impl]
-  | ^^^^^^^^^^^^^^^^^^^^ `dyn std::fmt::Display` is not defined in the current crate
-4 | impl std::fmt::Display for std::vec::Vec<i32> {
-  |                            ------------------ `Vec` is not defined in the current crate
-  |
-  = note: impl doesn't have any local type before any uncovered type parameters
-  = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
-  = note: define and implement a trait or new type instead
-  = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+error: aborting due to 1 previous error
 
-error[E0277]: the trait bound `Vec<i32>: Cacheable` is not satisfied
-  --> $DIR/trait_impl_orphan_violation.rs:4:28
-   |
- 3 | #[sassi::trait_impl]
-   | -------------------- required by a bound introduced by this call
- 4 | impl std::fmt::Display for std::vec::Vec<i32> {
-   |                            ^^^^^^^^^^^^^^^^^^ the trait `Cacheable` is not implemented for `Vec<i32>`
-   |
-note: required by a bound in `Sassi::pool`
-  --> sassi/src/sassi/orchestrator.rs:64:12
-   |
-62 |     pub fn pool<T>(&self) -> Option<Arc<Punnu<T>>>
-   |            ---- required by a bound in this associated function
-63 |     where
-64 |         T: Cacheable + 'static,
-   |            ^^^^^^^^^ required by this bound in `Sassi::pool`
-
-error[E0599]: the method `scope` exists for struct `Arc<Punnu<Vec<i32>>>`, but its trait bounds were not satisfied
- --> $DIR/trait_impl_orphan_violation.rs:3:1
-  |
-3 | #[sassi::trait_impl]
-  | ^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Arc<Punnu<Vec<i32>>>` due to unsatisfied trait bounds
-  |
-  = note: the following trait bounds were not satisfied:
-          `Vec<i32>: Cacheable`
-  = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0117, E0277, E0599.
-For more information about an error, try `rustc --explain E0117`.
+For more information about this error, try `rustc --explain E0117`.

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
@@ -41,19 +41,14 @@ note: required by a bound in `Sassi::pool`
    |            ^^^^^^^^^ required by this bound in `Sassi::pool`
 
 error[E0599]: the method `scope` exists for struct `Arc<Punnu<Vec<i32>>>`, but its trait bounds were not satisfied
-   --> $DIR/trait_impl_orphan_violation.rs:3:1
-    |
-  3 | #[sassi::trait_impl]
-    | ^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Arc<Punnu<Vec<i32>>>` due to unsatisfied trait bounds
-    |
-   ::: $RUST/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:438:1
-    |
-438 | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
-    | ------------------------------------------------------------------------------------------------ doesn't satisfy `Vec<i32>: Cacheable`
-    |
-    = note: the following trait bounds were not satisfied:
-            `Vec<i32>: Cacheable`
-    = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $DIR/trait_impl_orphan_violation.rs:3:1
+  |
+3 | #[sassi::trait_impl]
+  | ^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Arc<Punnu<Vec<i32>>>` due to unsatisfied trait bounds
+  |
+  = note: the following trait bounds were not satisfied:
+          `Vec<i32>: Cacheable`
+  = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
@@ -1,15 +1,61 @@
 error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
- --> $DIR/trait_impl_orphan_violation.rs:8:1
+ --> $DIR/trait_impl_orphan_violation.rs:4:1
   |
-8 | impl std::fmt::Display for String {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^------
+4 | impl std::fmt::Display for std::vec::Vec<i32> {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------
   |                            |
-  |                            `String` is not defined in the current crate
+  |                            `Vec` is not defined in the current crate
   |
   = note: impl doesn't have any local type before any uncovered type parameters
   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
   = note: define and implement a trait or new type instead
 
-error: aborting due to 1 previous error
+error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
+ --> $DIR/trait_impl_orphan_violation.rs:3:1
+  |
+3 | #[sassi::trait_impl]
+  | ^^^^^^^^^^^^^^^^^^^^ `dyn std::fmt::Display` is not defined in the current crate
+4 | impl std::fmt::Display for std::vec::Vec<i32> {
+  |                            ------------------ `Vec` is not defined in the current crate
+  |
+  = note: impl doesn't have any local type before any uncovered type parameters
+  = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+  = note: define and implement a trait or new type instead
+  = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0117`.
+error[E0277]: the trait bound `Vec<i32>: Cacheable` is not satisfied
+  --> $DIR/trait_impl_orphan_violation.rs:4:28
+   |
+ 3 | #[sassi::trait_impl]
+   | -------------------- required by a bound introduced by this call
+ 4 | impl std::fmt::Display for std::vec::Vec<i32> {
+   |                            ^^^^^^^^^^^^^^^^^^ the trait `Cacheable` is not implemented for `Vec<i32>`
+   |
+note: required by a bound in `Sassi::pool`
+  --> sassi/src/sassi/orchestrator.rs:64:12
+   |
+62 |     pub fn pool<T>(&self) -> Option<Arc<Punnu<T>>>
+   |            ---- required by a bound in this associated function
+63 |     where
+64 |         T: Cacheable + 'static,
+   |            ^^^^^^^^^ required by this bound in `Sassi::pool`
+
+error[E0599]: the method `scope` exists for struct `Arc<Punnu<Vec<i32>>>`, but its trait bounds were not satisfied
+   --> $DIR/trait_impl_orphan_violation.rs:3:1
+    |
+  3 | #[sassi::trait_impl]
+    | ^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Arc<Punnu<Vec<i32>>>` due to unsatisfied trait bounds
+    |
+   ::: $RUST/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:438:1
+    |
+438 | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+    | ------------------------------------------------------------------------------------------------ doesn't satisfy `Vec<i32>: Cacheable`
+    |
+    = note: the following trait bounds were not satisfied:
+            `Vec<i32>: Cacheable`
+    = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0117, E0277, E0599.
+For more information about an error, try `rustc --explain E0117`.

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
@@ -1,0 +1,61 @@
+error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
+ --> $DIR/trait_impl_orphan_violation.rs:4:1
+  |
+4 | impl std::fmt::Display for std::vec::Vec<i32> {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------
+  |                            |
+  |                            `Vec` is not defined in the current crate
+  |
+  = note: impl doesn't have any local type before any uncovered type parameters
+  = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+  = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
+ --> $DIR/trait_impl_orphan_violation.rs:3:1
+  |
+3 | #[sassi::trait_impl]
+  | ^^^^^^^^^^^^^^^^^^^^ `dyn std::fmt::Display` is not defined in the current crate
+4 | impl std::fmt::Display for std::vec::Vec<i32> {
+  |                            ------------------ `Vec` is not defined in the current crate
+  |
+  = note: impl doesn't have any local type before any uncovered type parameters
+  = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+  = note: define and implement a trait or new type instead
+  = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Vec<i32>: Cacheable` is not satisfied
+  --> $DIR/trait_impl_orphan_violation.rs:4:28
+   |
+ 3 | #[sassi::trait_impl]
+   | -------------------- required by a bound introduced by this call
+ 4 | impl std::fmt::Display for std::vec::Vec<i32> {
+   |                            ^^^^^^^^^^^^^^^^^^ the trait `Cacheable` is not implemented for `Vec<i32>`
+   |
+note: required by a bound in `Sassi::pool`
+  --> sassi/src/sassi/orchestrator.rs:64:12
+   |
+62 |     pub fn pool<T>(&self) -> Option<Arc<Punnu<T>>>
+   |            ---- required by a bound in this associated function
+63 |     where
+64 |         T: Cacheable + 'static,
+   |            ^^^^^^^^^ required by this bound in `Sassi::pool`
+
+error[E0599]: the method `scope` exists for struct `Arc<Punnu<Vec<i32>>>`, but its trait bounds were not satisfied
+   --> $DIR/trait_impl_orphan_violation.rs:3:1
+    |
+  3 | #[sassi::trait_impl]
+    | ^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Arc<Punnu<Vec<i32>>>` due to unsatisfied trait bounds
+    |
+   ::: $RUST/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:438:1
+    |
+438 | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+    | ------------------------------------------------------------------------------------------------ doesn't satisfy `Vec<i32>: Cacheable`
+    |
+    = note: the following trait bounds were not satisfied:
+            `Vec<i32>: Cacheable`
+    = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0117, E0277, E0599.
+For more information about an error, try `rustc --explain E0117`.

--- a/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
+++ b/sassi-macros/tests/lihaaf/compile_fail/trait_impl_orphan_violation.stderr
@@ -1,60 +1,15 @@
 error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
- --> $DIR/trait_impl_orphan_violation.rs:4:1
+ --> $DIR/trait_impl_orphan_violation.rs:8:1
   |
-4 | impl std::fmt::Display for std::vec::Vec<i32> {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------
+8 | impl std::fmt::Display for String {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^------
   |                            |
-  |                            `Vec` is not defined in the current crate
+  |                            `String` is not defined in the current crate
   |
   = note: impl doesn't have any local type before any uncovered type parameters
   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
   = note: define and implement a trait or new type instead
 
-error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
- --> $DIR/trait_impl_orphan_violation.rs:3:1
-  |
-3 | #[sassi::trait_impl]
-  | ^^^^^^^^^^^^^^^^^^^^ `dyn std::fmt::Display` is not defined in the current crate
-4 | impl std::fmt::Display for std::vec::Vec<i32> {
-  |                            ------------------ `Vec` is not defined in the current crate
-  |
-  = note: impl doesn't have any local type before any uncovered type parameters
-  = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
-  = note: define and implement a trait or new type instead
-  = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+error: aborting due to 1 previous error
 
-error[E0277]: the trait bound `Vec<i32>: Cacheable` is not satisfied
-  --> $DIR/trait_impl_orphan_violation.rs:4:28
-   |
- 3 | #[sassi::trait_impl]
-   | -------------------- required by a bound introduced by this call
- 4 | impl std::fmt::Display for std::vec::Vec<i32> {
-   |                            ^^^^^^^^^^^^^^^^^^ the trait `Cacheable` is not implemented for `Vec<i32>`
-   |
-note: required by a bound in `Sassi::pool`
-  --> sassi/src/sassi/orchestrator.rs:64:12
-   |
-62 |     pub fn pool<T>(&self) -> Option<Arc<Punnu<T>>>
-   |            ---- required by a bound in this associated function
-63 |     where
-64 |         T: Cacheable + 'static,
-   |            ^^^^^^^^^ required by this bound in `Sassi::pool`
-
-error[E0599]: the method `scope` exists for struct `Arc<Punnu<Vec<i32>>>`, but its trait bounds were not satisfied
-   --> $DIR/trait_impl_orphan_violation.rs:3:1
-    |
-  3 | #[sassi::trait_impl]
-    | ^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Arc<Punnu<Vec<i32>>>` due to unsatisfied trait bounds
-    |
-   ::: $RUST/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs
-   |
-   | $RUST_SRC
-   |
-    = note: the following trait bounds were not satisfied:
-            `Vec<i32>: Cacheable`
-    = note: this error originates in the attribute macro `sassi::trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0117, E0277, E0599.
-For more information about an error, try `rustc --explain E0117`.
+For more information about this error, try `rustc --explain E0117`.

--- a/sassi-macros/tests/lihaaf/compile_pass/forbid_unsafe_code_adopter.rs
+++ b/sassi-macros/tests/lihaaf/compile_pass/forbid_unsafe_code_adopter.rs
@@ -4,8 +4,7 @@
 //! Proves that the `inventory::submit!` expansion does not surface
 //! unsafe attribute syntax (`unsafe(link_section = ...)`) at the
 //! adopter call site — the unsafe machinery is fully encapsulated
-//! inside the `inventory` crate. Closes round-2 BLOCK-1 elevation
-//! risk on the macro emission audit.
+//! inside the `inventory` crate.
 
 #![forbid(unsafe_code)]
 

--- a/sassi-macros/tests/lihaaf/compile_pass/trait_impl_marker.rs
+++ b/sassi-macros/tests/lihaaf/compile_pass/trait_impl_marker.rs
@@ -1,0 +1,31 @@
+use sassi::{Cacheable, TraitImpl};
+use std::sync::Arc;
+
+trait Searchable: Send + Sync {
+    fn cols(&self) -> &'static [&'static str];
+}
+
+#[derive(Debug, Clone)]
+struct Vehicle { id: i64 }
+
+#[derive(Default)]
+struct EmptyFields;
+
+impl Cacheable for Vehicle {
+    type Id = i64;
+    type Fields = EmptyFields;
+    fn id(&self) -> i64 { self.id }
+    fn fields() -> EmptyFields { EmptyFields }
+}
+
+#[sassi::trait_impl]
+impl Searchable for Vehicle {
+    fn cols(&self) -> &'static [&'static str] { &["title"] }
+}
+
+fn requires_marker<T: TraitImpl<dyn Searchable>>() {}
+
+fn main() {
+    requires_marker::<Vehicle>();
+    let _ = Arc::new(Vehicle { id: 1 });
+}

--- a/sassi/Cargo.toml
+++ b/sassi/Cargo.toml
@@ -56,7 +56,7 @@ fastrand = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
-sassi-macros = { path = "../sassi-macros", version = "0.1.0-beta.4" }
+sassi-macros = { path = "../sassi-macros", version = "0.1.0-beta.5" }
 inventory = { workspace = true }
 # `web-time` is a drop-in for `std::time::Instant` that works on
 # `wasm32-unknown-unknown`. Used only on wasm — native builds keep

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -103,7 +103,7 @@ pub use punnu::{
 };
 #[cfg(feature = "serde")]
 pub use punnu::{PunnuRestoreStats, SnapshotMode};
-pub use sassi::Sassi;
+pub use sassi::{Sassi, TraitImpl};
 pub use time::Instant;
 pub use watermark::{DeltaSyncCacheable, MonotonicWatermark};
 

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -60,8 +60,7 @@
 //! ```
 //!
 //! The derive requires a field literally named `id`; types whose identifier
-//! uses a different name (e.g. `user_id`) must hand-implement [`Cacheable`]
-//! until v0.2 adds `#[cacheable(id)]`.
+//! uses a different name (e.g. `user_id`) must hand-implement [`Cacheable`].
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -121,6 +121,7 @@ pub use sassi_macros::{Cacheable, trait_impl};
 /// private module layout.
 #[doc(hidden)]
 pub mod __private {
+    pub use crate::sassi::trait_registry::__sealed::Sealed;
     pub use crate::sassi::trait_registry::TraitImplEntry;
     pub use inventory;
     #[cfg(feature = "serde")]

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -16,9 +16,10 @@
 //! `!` operators and evaluate through the same in-memory path on every
 //! supported target.
 //!
-//! Beta release (v0.1.0-beta.4). The core public surface is available now:
+//! Beta release (v0.1.0-beta.5). The core public surface is available now:
 //! [`Cacheable`] identities, pools, in-memory scopes, lazy fetch helpers,
-//! TTL/LRU policy, event streams, and atomic delta application.
+//! TTL/LRU policy, event streams, atomic delta application, and trait-narrowed
+//! scope filtering via [`PunnuScope::filter_impl`](crate::punnu::PunnuScope::filter_impl).
 //!
 //! # Quick tour
 //!
@@ -26,7 +27,7 @@
 //! (CI-verified by the workspace `cargo clippy --all-targets` gate) and in
 //! the lead `README.md`.
 //!
-//! [example]: https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.4/sassi/examples/quick_tour.rs
+//! [example]: https://github.com/TarunvirBains/sassi/blob/v0.1.0-beta.5/sassi/examples/quick_tour.rs
 //!
 //! ```
 //! use sassi::{Cacheable, MemQ, Punnu};

--- a/sassi/src/punnu/scope.rs
+++ b/sassi/src/punnu/scope.rs
@@ -85,14 +85,62 @@ impl<T: Cacheable> PunnuScope<T> {
         self.then(MemQ::filter(predicate))
     }
 
-    /// Assert that every entry in this scope implements `Trait`.
+    /// Narrow this scope to entries whose type implements `Trait`.
     ///
-    /// This is a compile-time guarantee with zero runtime cost. The
-    /// bound `T: TraitImpl<Trait>` proves that the pool type was
-    /// registered via `#[sassi::trait_impl]`, so every `Arc<T>`
-    /// entry already satisfies `Trait`. The method returns `self`
-    /// unchanged; the narrowing is enforced at the type level, not
-    /// through a runtime filter.
+    /// # What
+    /// Restricts the scope to cached entries that participate in `Trait`'s
+    /// cross-type registry (registered via `#[sassi::trait_impl]`). Because
+    /// a [`Punnu<T>`](crate::punnu::Punnu) holds exactly one concrete type,
+    /// the `T: TraitImpl<Trait>` bound proves the *entire* pool qualifies —
+    /// so this is a compile-time-checked identity narrowing, not a runtime
+    /// predicate scan. The bound cannot be satisfied by an ordinary hand-written `impl TraitImpl<dyn Trait>` — `TraitImpl` has a sealed supertrait that only the `#[sassi::trait_impl]` expansion emits. (Reaching into `#[doc(hidden)] sassi::__private` to forge the supertrait explicitly is possible but warranty-voiding.)
+    ///
+    /// # Why
+    /// Use `filter_impl` for the *single-type* trait query — when you have a
+    /// concrete `Punnu<T>` and want to assert (and document, in types) that
+    /// `T` implements `Trait`, while keeping the concrete `Arc<T>` entries.
+    /// For the *cross-type* query that collects `Arc<dyn Trait>` across every
+    /// registered pool, use [`Sassi::all_impl`](crate::Sassi::all_impl)
+    /// instead. `filter_impl` keeps the concrete type; `all_impl` erases it.
+    ///
+    /// # How
+    /// ```
+    /// use sassi::{Cacheable, MemQ, Punnu};
+    /// use std::sync::Arc;
+    ///
+    /// trait IsVehicle: Send + Sync { fn wheels(&self) -> u8; }
+    ///
+    /// #[derive(Clone)]
+    /// struct Car { id: i64 }
+    /// # #[derive(Default)] struct F;
+    /// impl Cacheable for Car {
+    ///     type Id = i64; type Fields = F;
+    ///     fn id(&self) -> i64 { self.id }
+    ///     fn fields() -> F { F }
+    /// }
+    ///
+    /// #[sassi::trait_impl]
+    /// impl IsVehicle for Car { fn wheels(&self) -> u8 { 4 } }
+    ///
+    /// # async fn run() {
+    /// let cars = Punnu::<Car>::builder().build();
+    /// cars.insert(Car { id: 1 }).await.unwrap();
+    /// let v: Vec<Arc<Car>> = cars
+    ///     .scope(Vec::<MemQ<Car>>::new())
+    ///     .filter_impl::<dyn IsVehicle>()
+    ///     .collect();
+    /// assert_eq!(v.len(), 1);
+    /// # }
+    /// # let rt = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
+    /// # rt.block_on(run());
+    /// ```
+    ///
+    /// # Where
+    /// Reach for `filter_impl` when you have a concrete `Punnu<T>` and want
+    /// the compile-time, zero-cost assertion that `T` is trait-registered
+    /// (e.g. before forwarding the scope to trait-generic code). For the
+    /// erased, cross-pool collection, use
+    /// [`Sassi::all_impl`](crate::Sassi::all_impl).
     pub fn filter_impl<Trait>(self) -> Self
     where
         Trait: ?Sized + 'static,

--- a/sassi/src/punnu/scope.rs
+++ b/sassi/src/punnu/scope.rs
@@ -9,6 +9,7 @@
 use crate::cacheable::Cacheable;
 use crate::predicate::{IntoBasicPredicate, MemQ};
 use crate::punnu::Punnu;
+use crate::sassi::trait_registry::TraitImpl;
 use std::cmp::Ordering;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -82,6 +83,22 @@ impl<T: Cacheable> PunnuScope<T> {
         F: Fn(&T) -> bool + Send + Sync + 'static,
     {
         self.then(MemQ::filter(predicate))
+    }
+
+    /// Assert that every entry in this scope implements `Trait`.
+    ///
+    /// This is a compile-time guarantee with zero runtime cost. The
+    /// bound `T: TraitImpl<Trait>` proves that the pool type was
+    /// registered via `#[sassi::trait_impl]`, so every `Arc<T>`
+    /// entry already satisfies `Trait`. The method returns `self`
+    /// unchanged; the narrowing is enforced at the type level, not
+    /// through a runtime filter.
+    pub fn filter_impl<Trait>(self) -> Self
+    where
+        Trait: ?Sized + 'static,
+        T: TraitImpl<Trait>,
+    {
+        self
     }
 
     /// Append an `Arc<T>` mapper.

--- a/sassi/src/sassi/mod.rs
+++ b/sassi/src/sassi/mod.rs
@@ -10,4 +10,4 @@ pub mod orchestrator;
 pub mod trait_registry;
 
 pub use orchestrator::Sassi;
-pub use trait_registry::TraitRegistry;
+pub use trait_registry::{TraitImpl, TraitRegistry};

--- a/sassi/src/sassi/trait_registry.rs
+++ b/sassi/src/sassi/trait_registry.rs
@@ -79,14 +79,41 @@ pub struct TraitImplEntry {
 
 inventory::collect!(TraitImplEntry);
 
-/// Compile-time marker proving that a concrete type is registered as
-/// an implementation of a trait for Sassi cross-type queries.
+/// Compile-time marker: `T` has a registered implementation of `Trait`
+/// via `#[sassi::trait_impl]`.
 ///
-/// One `impl TraitImpl<dyn Trait> for Type` is emitted by each
-/// `#[sassi::trait_impl]` expansion. Callers use the bound
-/// `T: TraitImpl<dyn Trait>` to prove that every entry in a
-/// single-type [`PunnuScope`](crate::punnu::PunnuScope) implements
-/// `Trait`, enabling zero-cost trait narrowing at compile time.
+/// # What
+/// One marker impl is emitted per `(Type, Trait)` pair the
+/// `#[sassi::trait_impl]` attribute macro processes. The trait carries no
+/// methods and no runtime cost — it exists purely so method bounds (most
+/// notably [`PunnuScope::filter_impl`](crate::punnu::PunnuScope::filter_impl))
+/// can require, at compile time, that the cached type participates in a
+/// given trait's cross-type registry. The marker has a sealed supertrait — a plain hand-written `impl TraitImpl<dyn Trait> for Type {}` is rejected at compile time; registration goes through `#[sassi::trait_impl]`. (Reaching directly into `#[doc(hidden)] sassi::__private` is possible but explicitly warranty-voiding, and mirrors the existing treatment of `TraitImplEntry`.)
+///
+/// # Why
+/// [`Sassi::all_impl`](crate::Sassi::all_impl) answers the *cross-type*
+/// question ("every cached value implementing `Trait`, across pools") and
+/// returns erased `Arc<dyn Trait>`. `filter_impl` answers the *single-type*
+/// question ("narrow this `Punnu<T>` scope to entries that implement
+/// `Trait`") while keeping the concrete `Arc<T>`. Because a `Punnu<T>` holds
+/// exactly one concrete type, the marker bound proves at compile time that
+/// the whole pool qualifies — turning the narrowing into a guarantee the
+/// type system enforces rather than a runtime predicate.
+///
+/// # How
+/// Adopters never write this impl by hand; `#[sassi::trait_impl]` emits it:
+/// ```ignore
+/// #[sassi::trait_impl]
+/// impl Searchable for Vehicle { /* ... */ }
+/// // expands to: impl Searchable for Vehicle { ... }
+/// //          +  impl ::sassi::TraitImpl<dyn Searchable> for Vehicle {}
+/// //          +  the sealed witness + inventory::submit!(TraitImplEntry { ... });
+/// ```
+///
+/// # Where
+/// Reach for the bound only in generic code that must require trait-registry
+/// participation (e.g. when forwarding to `filter_impl` from your own helper).
+/// Most call sites use `filter_impl` directly and never name `TraitImpl`.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not registered as an implementation of `{Trait}`",
     note = "apply `#[sassi::trait_impl]` to the `impl {Trait} for {Self}` block"

--- a/sassi/src/sassi/trait_registry.rs
+++ b/sassi/src/sassi/trait_registry.rs
@@ -41,6 +41,19 @@ use std::any::{Any, TypeId};
 use std::collections::HashSet;
 use std::sync::Arc;
 
+/// Module-private sealing trait. Only `#[sassi::trait_impl]` can emit an
+/// `impl Sealed<dyn Trait> for Type`, so adopters cannot hand-write a
+/// `TraitImpl<dyn Trait>` impl to forge cross-type registration. The
+/// `__` prefix marks this as internal plumbing, not adopter API.
+#[doc(hidden)]
+pub(crate) mod __sealed {
+    /// Sealed supertrait of [`super::TraitImpl`], parameterized by the
+    /// trait object so a type sealed for `dyn A` is not thereby sealed
+    /// for `dyn B`. Re-exported as `crate::__private::Sealed` for the
+    /// macro; never named by adopters.
+    pub trait Sealed<Trait: ?Sized> {}
+}
+
 /// Type-erased collector emitted by `#[sassi::trait_impl]`.
 ///
 /// The returned `Box<dyn Any>` contains a `Vec<Arc<dyn Trait>>` for
@@ -78,7 +91,7 @@ inventory::collect!(TraitImplEntry);
     message = "`{Self}` is not registered as an implementation of `{Trait}`",
     note = "apply `#[sassi::trait_impl]` to the `impl {Trait} for {Self}` block"
 )]
-pub trait TraitImpl<Trait: ?Sized> {}
+pub trait TraitImpl<Trait: ?Sized>: __sealed::Sealed<Trait> {}
 
 /// Handle used by [`Sassi`] to query trait
 /// registrations.
@@ -150,6 +163,9 @@ mod marker_tests {
 
     struct Widget;
     impl Demo for Widget {}
+    // Stand-in witnesses matching what #[sassi::trait_impl] now emits:
+    // both the TraitImpl impl and the sealed supertrait witness.
+    impl super::__sealed::Sealed<dyn Demo> for Widget {}
     // Hand-written marker impl standing in for what the macro will emit.
     impl TraitImpl<dyn Demo> for Widget {}
 

--- a/sassi/src/sassi/trait_registry.rs
+++ b/sassi/src/sassi/trait_registry.rs
@@ -66,6 +66,20 @@ pub struct TraitImplEntry {
 
 inventory::collect!(TraitImplEntry);
 
+/// Compile-time marker proving that a concrete type is registered as
+/// an implementation of a trait for Sassi cross-type queries.
+///
+/// One `impl TraitImpl<dyn Trait> for Type` is emitted by each
+/// `#[sassi::trait_impl]` expansion. Callers use the bound
+/// `T: TraitImpl<dyn Trait>` to prove that every entry in a
+/// single-type [`PunnuScope`](crate::punnu::PunnuScope) implements
+/// `Trait`, enabling zero-cost trait narrowing at compile time.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not registered as an implementation of `{Trait}`",
+    note = "apply `#[sassi::trait_impl]` to the `impl {Trait} for {Self}` block"
+)]
+pub trait TraitImpl<Trait: ?Sized> {}
+
 /// Handle used by [`Sassi`] to query trait
 /// registrations.
 ///
@@ -125,5 +139,24 @@ impl TraitRegistry {
             }
         }
         out
+    }
+}
+
+#[cfg(test)]
+mod marker_tests {
+    use super::TraitImpl;
+
+    trait Demo: Send + Sync {}
+
+    struct Widget;
+    impl Demo for Widget {}
+    // Hand-written marker impl standing in for what the macro will emit.
+    impl TraitImpl<dyn Demo> for Widget {}
+
+    fn requires_marker<T: TraitImpl<dyn Demo>>() {}
+
+    #[test]
+    fn marker_bound_resolves_for_registered_pair() {
+        requires_marker::<Widget>();
     }
 }

--- a/sassi/tests/scope_filter_impl.rs
+++ b/sassi/tests/scope_filter_impl.rs
@@ -1,0 +1,65 @@
+use sassi::{Cacheable, MemQ, Punnu};
+use std::sync::Arc;
+
+#[allow(dead_code)]
+trait IsVehicle: Send + Sync {
+    fn wheels(&self) -> u8;
+}
+
+#[derive(Debug, Clone)]
+struct Car {
+    id: i64,
+}
+
+#[derive(Default)]
+struct EmptyFields;
+
+impl Cacheable for Car {
+    type Id = i64;
+    type Fields = EmptyFields;
+    fn id(&self) -> i64 {
+        self.id
+    }
+    fn fields() -> EmptyFields {
+        EmptyFields
+    }
+}
+
+#[sassi::trait_impl]
+impl IsVehicle for Car {
+    fn wheels(&self) -> u8 {
+        4
+    }
+}
+
+#[tokio::test]
+async fn filter_impl_returns_all_entries_of_implementing_type() {
+    let cars = Punnu::<Car>::builder().build();
+    cars.insert(Car { id: 1 }).await.unwrap();
+    cars.insert(Car { id: 2 }).await.unwrap();
+
+    let got: Vec<Arc<Car>> = cars
+        .scope(Vec::<MemQ<Car>>::new())
+        .filter_impl::<dyn IsVehicle>()
+        .collect();
+
+    let mut ids: Vec<i64> = got.iter().map(|c| c.id).collect();
+    ids.sort();
+    assert_eq!(ids, vec![1, 2]);
+}
+
+#[tokio::test]
+async fn filter_impl_composes_with_other_filters() {
+    let cars = Punnu::<Car>::builder().build();
+    cars.insert(Car { id: 1 }).await.unwrap();
+    cars.insert(Car { id: 2 }).await.unwrap();
+
+    let got: Vec<Arc<Car>> = cars
+        .scope(Vec::<MemQ<Car>>::new())
+        .filter_impl::<dyn IsVehicle>()
+        .filter_closure(|c| c.id == 2)
+        .collect();
+
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].id, 2);
+}


### PR DESCRIPTION
## Summary

Implements `PunnuScope::filter_impl::<dyn Trait>()` — the single-type, compile-time trait-narrowed scope filter specified in the Sassi design (§3.6). This is the final piece of the trait integration trio alongside `#[sassi::trait_impl]` (macro) and `Sassi::all_impl::<dyn Trait>()` (cross-type).

## What changed

### New public API
- **`TraitImpl<Trait: ?Sized>`** — zero-cost compile-time marker trait (`sassi/src/sassi/trait_registry.rs`). One impl emitted per `(Type, Trait)` pair by `#[sassi::trait_impl]`. Includes `#[diagnostic::on_unimplemented]` for actionable error messages.
- **`PunnuScope::filter_impl::<Trait>()`** — narrows scope to entries implementing `Trait`. Gated on `T: TraitImpl<Trait>`, so the narrowing is a compile-time guarantee (identity at runtime for single-type pools).

### Macro changes
- `#[sassi::trait_impl]` now emits `impl TraitImpl<dyn Trait> for Type {}` alongside the existing `TraitImplEntry` registration — adopters write no new attribute.
- Seam extracted: private `trait_impl_impl(TokenStream2, TokenStream2) -> TokenStream2` enables unit testing without `proc_macro::TokenStream`.

### Tests
- Integration test: happy path + composition with other filters (`sassi/tests/scope_filter_impl.rs`)
- Compile-pass lihaaf fixture: marker bound resolves after `#[sassi::trait_impl]`
- Compile-fail fixtures: orphan-rule coherence + marker enforcement (type without `#[sassi::trait_impl]` cannot call `filter_impl`)

### Version
- Bumped to `0.1.0-beta.5` (workspace version + two hardcoded path-dep strings).

## API shape

```rust
let overdue: Vec<Arc<User>> = punnu
    .scope(Vec::<MemQ<User>>::new())
    .filter_impl::<dyn IsOverdue>()
    .collect();
```

## Commits

| Commit | Description |
|--------|-------------|
| `244bfd4` | feat: add TraitImpl&lt;Trait&gt; compile-time marker |
| `4ab6a91` | feat: emit TraitImpl marker from #[sassi::trait_impl] |
| `245eb56` | feat: implement PunnuScope::filter_impl |
| `b35cf92` | chore: bump to 0.1.0-beta.5 |
| `c877202` | fix: bless compile-fail stderr snapshots + remove unused imports |
| `cbcde7a` | docs: update lib.rs version and surface list |

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -D warnings` — clean
- `cargo test --workspace` — 285 passed
- `cargo lihaaf` — 33/33 fixtures OK
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean

Closes #37

Please visit https://kindnudge.app