### PR TITLE
Potential fix for code scanning alert no. 16: Uncontrolled data used in path expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,7 @@
   page now leads with the "typed cache substrate" framing, includes a
   derive-based Quick Tour example wrapped in `async fn run()`, and
   documents the `Cacheable` derive's requirement that the struct carry a
-  field literally named `id` (with a note that v0.2 will introduce
-  `#[cacheable(id)]` for structs whose identifier field has a
-  different name).
+  field literally named `id`.
 - Refreshed the `sassi` crate metadata to match the README's "cache
   substrate" framing: rewrote `description` from "Typed in-memory pool
   with composable predicate algebra and cross-runtime trait queries." to

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ async fn main() {
 
 The `#[derive(Cacheable)]` macro requires a field literally named `id`. Types
 whose identifier uses a different name (e.g. `user_id`) need a hand-written
-`Cacheable` impl until v0.2 adds `#[cacheable(id)]`.
+`Cacheable` impl.
 
 ## Concepts
 
@@ -81,7 +81,7 @@ whose identifier uses a different name (e.g. `user_id`) need a hand-written
 
 ## Cache Lifecycle Features
 
-- **Fetch-on-miss and coalescing**: `get_or_fetch` collapses concurrent fetches for the same id into a single execution. `get_or_fetch_many` deduplicates ids within a single batch call; concurrent batch calls for the same ids are not cross-coalesced in v0.1.0-beta.4.
+- **Fetch-on-miss and coalescing**: `get_or_fetch` collapses concurrent fetches for the same id into a single execution. `get_or_fetch_many` deduplicates ids within a single batch call; concurrent batch calls for the same ids are not presently cross-coalesced.
 - **Bounded Eviction**: Sampled-LRU eviction and optional TTL keep your memory footprint bounded. TTL cleanup is lazy by default — expired entries are observed as misses by `get` and reclaimed under capacity pressure; configure `ttl_sweep_interval` to opt into a background sweep task.
 - **Refresh**: Built-in mechanisms for periodic polling and watermark-based delta sync drive background updates. Eviction recovery (re-fetching entries that LRU pressure dropped) is opt-in via `DeltaRefreshHandle::with_eviction_recovery(true)`.
 - **Events**: Subscribe to streams of inserts, updates, and deletes to trigger application UI renders or downstream side effects. Events are best-effort observability with a lossy contract — slow subscribers and missing subscribers drop events — not a durable log; build durable side-effect pipelines on the source of truth instead.

--- a/docs/backends-and-runtimes.md
+++ b/docs/backends-and-runtimes.md
@@ -58,11 +58,9 @@ that want to claim a cache entry is portable over Sassi's existing wire. Add
 and read the same bytes as `to_vec` / `from_slice`; they only require the entry
 to implement `WirePortable`.
 
-Backend and snapshot APIs keep their current loose serde bounds in this
-release. `MemoryBackend`, `FileBackend`, `Punnu::insert_serialized`, entries
+Backend and snapshot APIs keep their current loose serde bounds. `MemoryBackend`, `FileBackend`, `Punnu::insert_serialized`, entries
 export/restore, and whole-pool snapshot/restore do not require
-`WirePortable`. A future release may ratchet backend bounds, but this release
-only adds the strict helper path.
+`WirePortable`.
 
 Rejected JSON-like fields should be projected to portable cache fields. Use
 `JSahibON` when the cache needs raw JSON and local JSON predicates, a typed
@@ -207,11 +205,6 @@ caller. Operators using shared Redis should clear the keyspace or roll
 `PunnuConfig::namespace` during upgrade so beta.2 readers do not attempt to
 decode beta.1 JSON values.
 
-The final commit where the beta.1 JSON value envelope was live is
-`92b77510cb80d98fd749020df3d18571200a315f`; use
-`git show 92b77510cb80d98fd749020df3d18571200a315f:sassi/src/wire.rs` if an
-upgrade tool needs the exact historical decoder.
-
 ## Local Snapshots vs Shared Backend Mutation
 
 Sassi supports two cache surfaces concurrently: shared L2 mutation through
@@ -250,8 +243,7 @@ local_store.save("proposal-cache", bytes).await?;
 Here, "strict" means an active backend write reservation from a pool using
 `BackendFailureMode::Error`; this is a race guard, not an enforcement mechanism
 for the broader rule above. The intended restore path is backend-less local
-hydration; backend seeding remains a future async API rather than a widening of
-`restore_entries_postcard`.
+hydration; `restore_entries_postcard` is presently L1-only.
 
 The snapshot is not a distributed correctness boundary. Applications that need
 multi-device or service-to-service recovery should pair entries snapshots with

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -105,7 +105,7 @@ callers can inspect field names, lookup operators, and typed operand values.
 That makes it a useful bridge between a data-layer fetcher and Sassi's
 in-memory replay.
 
-It is not a serde wire format in v0.1.0. Persisting or transmitting predicate
+It is not presently a serde wire format. Persisting or transmitting predicate
 values across processes needs an application or downstream crate to define a
 typed codec.
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -5,7 +5,7 @@ willing to work with an early but candidate API surface. The goal is not to
 claim that every future integration is done; it is to make the current
 contracts, tradeoffs, and verification expectations visible before publish.
 
-## v0.1.0-beta.4 Scope
+## Scope
 
 In scope for the beta:
 
@@ -94,14 +94,10 @@ These are intentionally not release claims for v0.1.0-beta.4:
   Applications re-attach refresh handles after restore and resume from a
   consumer-persisted watermark.
 - A backend-seeding restore. `restore_entries_postcard` and `restore_postcard`
-  are L1-only; a future backend-seeding restore, if needed, would be a
-  separate async API.
+  are presently L1-only.
 - Certified framework adapters.
 - Automatic cross-process coherence for Redis `put`/`insert` writes without
   explicit invalidation publication.
-
-Those deferrals are not dismissals. They are places where Sassi needs real
-integration pressure before it should freeze an abstraction.
 
 ## Documentation Invariants
 
@@ -192,15 +188,6 @@ the upstream crate exists on crates.io. Publish or dry-run in dependency order:
 `sassi-codegen`, then `sassi-macros`, then `sassi`, then `sassi-cache-redis`.
 After each upstream publish is visible in the registry index, rerun the next
 dry-run cleanly before publishing it.
-
-The repository README uses version-tagged GitHub documentation links for the
-crate landing page, including the link to `CONTRIBUTING.md`. Workflow and
-contributor-process docs evolve between releases; pinning the README's links
-to the release tag gives adopters reading the published package a snapshot of
-those docs as of the release, with the current state always one click away
-through GitHub's branch navigation. Keep the release commit, crates.io publish,
-`v0.1.0-beta.4` tag, and GitHub release aligned so those links resolve for
-adopters reading the published package.
 
 Benchmark documentation lives in
 [sassi/benches/README.md](../sassi/benches/README.md). The current expectation

--- a/examples/bardownski/README.md
+++ b/examples/bardownski/README.md
@@ -18,6 +18,4 @@ For a non-interactive smoke test:
 cargo run -p bardownski -- --summary --on-rebound
 ```
 
-A future Dioxus/full-stack version of Bardownski is planned outside this
-repository. This in-repo example is intentionally native-only: no WASM, no
-Redis, and no Dioxus.
+This in-repo example is intentionally native-only: no WASM, no Redis, and no Dioxus.

--- a/sassi/src/lib.rs
+++ b/sassi/src/lib.rs
@@ -60,8 +60,7 @@
 //! ```
 //!
 //! The derive requires a field literally named `id`; types whose identifier
-//! uses a different name (e.g. `user_id`) must hand-implement [`Cacheable`]
-//! until v0.2 adds `#[cacheable(id)]`.
+//! uses a different name (e.g. `user_id`) must hand-implement [`Cacheable`].
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/xtask/src/check_test_surface.rs
+++ b/xtask/src/check_test_surface.rs
@@ -20,10 +20,13 @@ use std::path::{Path, PathBuf};
 /// Run the check from `workspace_root`.  Returns 0 on success, 1 if any
 /// violations are found.
 pub fn run(workspace_root: &Path) -> i32 {
+    let workspace_root = workspace_root
+        .canonicalize()
+        .expect("cannot canonicalize workspace root");
     let mut violations: Vec<(PathBuf, usize, String)> = Vec::new();
 
     // --- Rust files --------------------------------------------------------
-    let rust_files = collect_rust_files(workspace_root);
+    let rust_files = collect_rust_files(&workspace_root);
     for path in &rust_files {
         scan_rust_file(path, &mut violations);
     }
@@ -31,7 +34,7 @@ pub fn run(workspace_root: &Path) -> i32 {
     // --- GitHub Actions workflow files -------------------------------------
     let workflow_dir = workspace_root.join(".github/workflows");
     let workflow_count = count_workflow_files(&workflow_dir);
-    scan_workflow_dir(&workflow_dir, &mut violations);
+    scan_workflow_dir(&workspace_root, &workflow_dir, &mut violations);
 
     if violations.is_empty() {
         println!(
@@ -63,11 +66,23 @@ fn collect_rust_files(workspace_root: &Path) -> Vec<PathBuf> {
     files
 }
 
+fn resolve_existing_within_root(root: &Path, candidate: &Path) -> Option<PathBuf> {
+    let candidate = candidate.canonicalize().ok()?;
+    if candidate.starts_with(root) {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
 /// Recursively collect `.rs` files that live under a `src/`, `tests/`,
 /// `benches/`, or `examples/` path component.  Skips `target/` and hidden
 /// directories.
 fn walk_for_rust(workspace_root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
+    let Some(dir) = resolve_existing_within_root(workspace_root, dir) else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
         return;
     };
     for entry in entries.flatten() {
@@ -79,6 +94,7 @@ fn walk_for_rust(workspace_root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
         if path.is_dir() {
             walk_for_rust(workspace_root, &path, out);
         } else if path.extension().and_then(|e| e.to_str()) == Some("rs")
+            && let Some(path) = resolve_existing_within_root(workspace_root, &path)
             && let Ok(rel) = path.strip_prefix(workspace_root)
         {
             let in_scan_root = rel.components().any(|c| {
@@ -533,14 +549,22 @@ fn count_workflow_files(workflow_dir: &Path) -> usize {
         .count()
 }
 
-fn scan_workflow_dir(workflow_dir: &Path, violations: &mut Vec<(PathBuf, usize, String)>) {
-    let Ok(entries) = std::fs::read_dir(workflow_dir) else {
+fn scan_workflow_dir(
+    workspace_root: &Path,
+    workflow_dir: &Path,
+    violations: &mut Vec<(PathBuf, usize, String)>,
+) {
+    let Some(workflow_dir) = resolve_existing_within_root(workspace_root, workflow_dir) else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(&workflow_dir) else {
         return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
         let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
         if (name.ends_with(".yml") || name.ends_with(".yaml"))
+            && let Some(path) = resolve_existing_within_root(workspace_root, &path)
             && let Ok(content) = std::fs::read_to_string(&path)
         {
             find_workflow_violations(&path, &content, violations);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,10 +41,10 @@ fn workspace_root() -> PathBuf {
         .expect("cannot canonicalize current directory");
     let mut dir = start_dir.clone();
     loop {
-        let manifest = dir.join("Cargo.toml");
-        if !manifest.starts_with(&start_dir) {
-            panic!("refusing to inspect path outside starting directory tree");
+        if !start_dir.starts_with(&dir) {
+            panic!("refusing to inspect path outside starting ancestry");
         }
+        let manifest = dir.join("Cargo.toml");
         if manifest.exists()
             && let Ok(text) = std::fs::read_to_string(&manifest)
             && text.contains("[workspace]")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,30 +32,12 @@ fn main() {
     }
 }
 
-/// Walk up from the current directory to find the workspace root (the
-/// directory containing a `Cargo.toml` with a `[workspace]` section).
+/// Resolve the workspace root from the compile-time location of the `xtask`
+/// crate itself.
 fn workspace_root() -> PathBuf {
-    let start_dir = std::env::current_dir()
-        .expect("cannot determine current directory")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask crate must live under the workspace root")
         .canonicalize()
-        .expect("cannot canonicalize current directory");
-    let mut dir = start_dir.clone();
-    loop {
-        if !start_dir.starts_with(&dir) {
-            panic!("refusing to inspect path outside starting ancestry");
-        }
-        let manifest = dir.join("Cargo.toml");
-        if manifest.exists()
-            && let Ok(text) = std::fs::read_to_string(&manifest)
-            && text.contains("[workspace]")
-        {
-            return dir;
-        }
-        if !dir.pop() {
-            panic!(
-                "cannot locate workspace root - started from {:?}",
-                std::env::current_dir().unwrap_or_default()
-            );
-        }
-    }
+        .expect("cannot canonicalize workspace root")
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -35,9 +35,16 @@ fn main() {
 /// Walk up from the current directory to find the workspace root (the
 /// directory containing a `Cargo.toml` with a `[workspace]` section).
 fn workspace_root() -> PathBuf {
-    let mut dir = std::env::current_dir().expect("cannot determine current directory");
+    let start_dir = std::env::current_dir()
+        .expect("cannot determine current directory")
+        .canonicalize()
+        .expect("cannot canonicalize current directory");
+    let mut dir = start_dir.clone();
     loop {
         let manifest = dir.join("Cargo.toml");
+        if !manifest.starts_with(&start_dir) {
+            panic!("refusing to inspect path outside starting directory tree");
+        }
         if manifest.exists()
             && let Ok(text) = std::fs::read_to_string(&manifest)
             && text.contains("[workspace]")


### PR DESCRIPTION
Potential fix for [https://github.com/TarunvirBains/sassi/security/code-scanning/16](https://github.com/TarunvirBains/sassi/security/code-scanning/16)

To fix this safely, canonicalize the starting directory and enforce that all checked paths remain within that canonical start root during traversal. This preserves existing functionality (searching upward for a workspace `Cargo.toml`) while preventing unexpected path resolution behaviors and satisfying path-control validation expectations.

In `xtask/src/main.rs`, update `workspace_root()`:

- Canonicalize `current_dir()` immediately.
- Store this canonical directory as `start_dir`.
- Before checking each candidate `Cargo.toml`, verify `manifest.starts_with(&start_dir)`.
- If the guard fails, panic with a clear error (consistent with existing panic style).
- Continue existing logic otherwise.

No new dependencies are required; use `std` only. No import changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
