### PR TITLE
[codex] fix remaining code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: stable
           components: clippy, rustfmt
 
       - name: Cache cargo registry and build
@@ -78,8 +79,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust + wasm32 target
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry/git/target (wasm)
@@ -132,7 +134,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install MSRV toolchain (matches workspace.package.rust-version)
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582
+        with:
+          toolchain: 1.95.0
 
       - name: Cache cargo registry/git/target (MSRV)
         uses: actions/cache@v5
@@ -172,7 +176,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@v5
@@ -210,7 +216,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@v5

--- a/.github/workflows/sensitive-info.yml
+++ b/.github/workflows/sensitive-info.yml
@@ -74,7 +74,9 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry/git/target (xtask)
         uses: actions/cache@v5

--- a/sassi-macros/tests/renamed_dependency.rs
+++ b/sassi-macros/tests/renamed_dependency.rs
@@ -13,12 +13,43 @@ fn macros_resolve_renamed_sassi_dependency() {
         .expect("sassi-macros should live below the workspace root")
         .to_path_buf();
     let sassi_path = repo_root.join("sassi");
+    let src_dir = crate_dir.join("src");
+    if !src_dir.starts_with(&crate_dir) {
+        panic!(
+            "refusing to create directory outside test root: {}",
+            src_dir.display()
+        );
+    }
     let target_dir = crate_dir.join("target");
+    if !target_dir.starts_with(&crate_dir) {
+        panic!(
+            "refusing to use target directory outside test root: {}",
+            target_dir.display()
+        );
+    }
+    let manifest_path = crate_dir.join("Cargo.toml");
+    if !manifest_path.starts_with(&crate_dir) {
+        panic!(
+            "refusing to use manifest path outside test root: {}",
+            manifest_path.display()
+        );
+    }
 
-    fs::create_dir_all(crate_dir.join("src")).expect("create temp crate src");
-    fs::write(
-        crate_dir.join("Cargo.toml"),
-        format!(
+    fs::create_dir_all(&src_dir).expect("create temp crate src");
+    let safe_write = |rel: &str, contents: &str| {
+        let candidate = crate_dir.join(rel);
+        if !candidate.starts_with(&crate_dir) {
+            panic!(
+                "refusing to write outside test root: {}",
+                candidate.display()
+            );
+        }
+        fs::write(candidate, contents).unwrap();
+    };
+
+    safe_write(
+        "Cargo.toml",
+        &format!(
             r#"[package]
 name = "sassi-renamed-dependency-fixture"
 version = "0.0.0"
@@ -32,11 +63,10 @@ cache = {{ package = "sassi", path = "{}" }}
 "#,
             sassi_path.display()
         ),
-    )
-    .expect("write fixture Cargo.toml");
+    );
 
-    fs::write(
-        crate_dir.join("src/main.rs"),
+    safe_write(
+        "src/main.rs",
         r#"
 use cache::{Cacheable, Sassi};
 use std::any::Any;
@@ -65,15 +95,14 @@ fn main() {
     let _registered: Vec<Arc<dyn Nameable>> = Sassi::new().all_impl::<dyn Nameable>();
 }
 "#,
-    )
-    .expect("write fixture main.rs");
+    );
 
     let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
         .arg("check")
         .arg("--manifest-path")
-        .arg(crate_dir.join("Cargo.toml"))
+        .arg(&manifest_path)
         .arg("--target-dir")
-        .arg(target_dir)
+        .arg(&target_dir)
         .output()
         .expect("run cargo check for renamed dependency fixture");
 
@@ -86,10 +115,28 @@ fn main() {
     );
 }
 
-fn fresh_temp_crate(name: &str) -> PathBuf {
-    let path = std::env::temp_dir().join(format!("{name}-{}", std::process::id()));
-    if path.exists() {
-        fs::remove_dir_all(&path).expect("remove stale temp crate");
+fn is_within(parent: &Path, child: &Path) -> bool {
+    match (parent.canonicalize(), child.canonicalize()) {
+        (Ok(parent_abs), Ok(child_abs)) => child_abs.starts_with(parent_abs),
+        _ => false,
     }
-    path
+}
+
+fn fresh_temp_crate(name: &str) -> PathBuf {
+    let temp_root = std::env::temp_dir()
+        .canonicalize()
+        .expect("canonicalize temp root");
+    let path = temp_root.join(format!("{name}-{}", std::process::id()));
+    if path.exists() {
+        if is_within(&temp_root, &path) {
+            fs::remove_dir_all(&path).expect("remove stale temp crate");
+        } else {
+            panic!(
+                "refusing to remove path outside temp root: {}",
+                path.display()
+            );
+        }
+    }
+    fs::create_dir_all(&path).expect("create temp crate root");
+    path.canonicalize().expect("canonicalize temp crate root")
 }

--- a/sassi-macros/tests/renamed_dependency.rs
+++ b/sassi-macros/tests/renamed_dependency.rs
@@ -13,37 +13,13 @@ fn macros_resolve_renamed_sassi_dependency() {
         .expect("sassi-macros should live below the workspace root")
         .to_path_buf();
     let sassi_path = repo_root.join("sassi");
-    let src_dir = crate_dir.join("src");
-    if !src_dir.starts_with(&crate_dir) {
-        panic!(
-            "refusing to create directory outside test root: {}",
-            src_dir.display()
-        );
-    }
-    let target_dir = crate_dir.join("target");
-    if !target_dir.starts_with(&crate_dir) {
-        panic!(
-            "refusing to use target directory outside test root: {}",
-            target_dir.display()
-        );
-    }
-    let manifest_path = crate_dir.join("Cargo.toml");
-    if !manifest_path.starts_with(&crate_dir) {
-        panic!(
-            "refusing to use manifest path outside test root: {}",
-            manifest_path.display()
-        );
-    }
+    let src_dir = vetted_child_path(&crate_dir, "src");
+    let target_dir = vetted_child_path(&crate_dir, "target");
+    let manifest_path = vetted_child_path(&crate_dir, "Cargo.toml");
 
     fs::create_dir_all(&src_dir).expect("create temp crate src");
     let safe_write = |rel: &str, contents: &str| {
-        let candidate = crate_dir.join(rel);
-        if !candidate.starts_with(&crate_dir) {
-            panic!(
-                "refusing to write outside test root: {}",
-                candidate.display()
-            );
-        }
+        let candidate = vetted_child_path(&crate_dir, rel);
         fs::write(candidate, contents).unwrap();
     };
 
@@ -122,11 +98,55 @@ fn is_within(parent: &Path, child: &Path) -> bool {
     }
 }
 
+fn vetted_child_path(root: &Path, rel: &str) -> PathBuf {
+    let canonical_root = root
+        .canonicalize()
+        .unwrap_or_else(|err| panic!("canonicalize root {}: {err}", root.display()));
+    let candidate = canonical_root.join(rel);
+    match candidate.canonicalize() {
+        Ok(canonical_candidate) => {
+            if canonical_candidate.starts_with(&canonical_root) {
+                canonical_candidate
+            } else {
+                panic!(
+                    "refusing to use path outside test root: {}",
+                    canonical_candidate.display()
+                );
+            }
+        }
+        Err(_) => {
+            let parent = candidate.parent().unwrap_or_else(|| {
+                panic!(
+                    "refusing to use path without parent: {}",
+                    candidate.display()
+                )
+            });
+            let canonical_parent = parent
+                .canonicalize()
+                .unwrap_or_else(|err| panic!("canonicalize parent {}: {err}", parent.display()));
+            let vetted = canonical_parent.join(candidate.file_name().unwrap_or_else(|| {
+                panic!(
+                    "refusing to use path without file name: {}",
+                    candidate.display()
+                )
+            }));
+            if vetted.starts_with(&canonical_root) {
+                vetted
+            } else {
+                panic!(
+                    "refusing to use path outside test root: {}",
+                    vetted.display()
+                );
+            }
+        }
+    }
+}
+
 fn fresh_temp_crate(name: &str) -> PathBuf {
     let temp_root = std::env::temp_dir()
         .canonicalize()
         .expect("canonicalize temp root");
-    let path = temp_root.join(format!("{name}-{}", std::process::id()));
+    let path = vetted_child_path(&temp_root, &format!("{name}-{}", std::process::id()));
     if path.exists() {
         if is_within(&temp_root, &path) {
             fs::remove_dir_all(&path).expect("remove stale temp crate");


### PR DESCRIPTION
## What changed
- guarded the renamed dependency fixture test paths so temp-crate cleanup, file writes, and cargo command paths stay within the canonicalized temp root
- pinned every `dtolnay/rust-toolchain` action use in CI and sensitive-info workflows to exact commit SHAs while preserving the intended toolchain versions

## Why it changed
- GitHub code scanning still reported 11 open alerts after the previous merge
- the remaining findings were 5 `rust/path-injection` alerts in the renamed dependency fixture test and 6 `actions/unpinned-tag` alerts in GitHub workflows

## Impact
- fixture test path handling now follows the approved containment patterns instead of trusting derived temp paths implicitly
- workflow action resolution is deterministic and no longer depends on mutable tags

## Root cause
- the test created and reused temp paths derived from `temp_dir()` without canonicalized-root containment guards at every sink
- workflow steps referenced `dtolnay/rust-toolchain` by moving refs (`stable`, `1.95.0`) instead of pinned commit SHAs

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p sassi-macros --test renamed_dependency`
- `cargo test -p xtask`
